### PR TITLE
Fix/crash

### DIFF
--- a/Source/BottomView/StackView.swift
+++ b/Source/BottomView/StackView.swift
@@ -133,15 +133,6 @@ extension ImageStackView {
     }
   }
 
-  func suffix<T>(source: [T], count: Int) -> [T] {
-    if source.count <= count {
-      return source
-    }
-
-    let range = (source.count - count)...(source.count - 1)
-    return Array(source[range])
-  }
-
   private func animateImageView(imageView: UIImageView) {
     imageView.transform = CGAffineTransformMakeScale(0, 0)
 

--- a/Source/BottomView/StackView.swift
+++ b/Source/BottomView/StackView.swift
@@ -120,7 +120,7 @@ extension ImageStackView {
       return
     }
 
-    let photos = suffix(images, count: 4)
+    let photos = Array(images.suffix(4))
 
     for (index, view) in views.enumerate() {
       if index <= photos.count - 1 {

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -127,7 +127,14 @@ class CameraView: UIViewController {
       }, completion: { finished in
         self.captureSession.beginConfiguration()
         self.captureSession.removeInput(currentDeviceInput)
-        do { try self.captureSession.addInput(AVCaptureDeviceInput(device: self.captureDevice)) } catch {}
+
+        if self.captureDevice!.supportsAVCaptureSessionPreset(AVCaptureSessionPreset1280x720) {
+          self.captureSession.sessionPreset = AVCaptureSessionPreset1280x720
+        } else {
+          self.captureSession.sessionPreset = AVCaptureSessionPreset640x480
+        }
+
+        try! self.captureSession.addInput(AVCaptureDeviceInput(device: self.captureDevice))
         self.captureSession.commitConfiguration()
         UIView.animateWithDuration(0.7, animations: { [unowned self] in
           self.containerView.alpha = 0


### PR DESCRIPTION
Fix crash on 4S and other devices with low-resolution frontal camera. ImagePicker crashed when user tried to switch between frontal and back camera.
Refactored StackView, as there were no need to reinvent the suffix() function. 