### PR TITLE
Fix image rotation

### DIFF
--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -176,8 +176,13 @@ class CameraView: UIViewController {
         let image = self.cropImage(UIImage(data: imageData)!)
         let orientation = self.pictureOrientation()
         let assetsLibrary = ALAssetsLibrary()
-        self.delegate?.imageToLibrary(image)
         assetsLibrary.writeImageToSavedPhotosAlbum(image.CGImage, orientation: orientation, completionBlock: nil)
+
+
+        let rotatedImage = UIImage(CGImage: image.CGImage!,
+          scale: 1.0,
+          orientation: UIImageOrientation(rawValue: orientation.rawValue)!)
+        self.delegate?.imageToLibrary(rotatedImage)
       })
     })
   }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -178,7 +178,6 @@ class CameraView: UIViewController {
         let assetsLibrary = ALAssetsLibrary()
         assetsLibrary.writeImageToSavedPhotosAlbum(image.CGImage, orientation: orientation, completionBlock: nil)
 
-
         let rotatedImage = UIImage(CGImage: image.CGImage!,
           scale: 1.0,
           orientation: UIImageOrientation(rawValue: orientation.rawValue)!)


### PR DESCRIPTION
ImagePicker was saving picture with correct orientation but UIImage stored in memory still was with wrong orientation.

Now I am rotating both images.