### PR TITLE
Disable "flash" button if capture device has no flash.

### DIFF
--- a/Demo/ImagePickerDemo/Podfile.lock
+++ b/Demo/ImagePickerDemo/Podfile.lock
@@ -6,9 +6,9 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   ImagePicker:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   ImagePicker: 32becfa25b8e9179e60c45411b577340d35e3e32
 
-COCOAPODS: 0.39.0.beta.4
+COCOAPODS: 0.38.2

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -5,7 +5,6 @@ import AssetsLibrary
 protocol CameraViewDelegate: class {
 
   func setFlashButtonHidden(hidden: Bool)
-  func handleFlashButton(hide: Bool)
   func imageToLibrary()
 }
 
@@ -126,8 +125,6 @@ class CameraView: UIViewController {
 
     self.captureDevice = capturedDevices?.objectAtIndex(newDeviceIndex) as? AVCaptureDevice
     configureDevice()
-
-    delegate?.handleFlashButton(captureDevice.position == .Front)
 
     guard let currentCaptureDevice = self.captureDevice else { return }
     UIView.animateWithDuration(0.3, animations: { [unowned self] in
@@ -297,7 +294,6 @@ class CameraView: UIViewController {
     previewLayer.frame = view.layer.frame
     view.clipsToBounds = true
     captureSession.startRunning()
-    delegate?.handleFlashButton(captureDevice?.position == .Front)
     stillImageOutput = AVCaptureStillImageOutput()
     stillImageOutput?.outputSettings = [AVVideoCodecKey: AVVideoCodecJPEG]
     captureSession.addOutput(stillImageOutput)

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -50,13 +50,14 @@ class CameraView: UIViewController {
 
   let captureSession = AVCaptureSession()
   let devices = AVCaptureDevice.devices()
-    var captureDevice: AVCaptureDevice? {
-        didSet {
-            if let currentDevice = captureDevice {
-              delegate?.setFlashButtonHidden(!currentDevice.hasFlash)
-            }
-        }
+  var captureDevice: AVCaptureDevice? {
+    didSet {
+      if let currentDevice = captureDevice {
+        delegate?.setFlashButtonHidden(!currentDevice.hasFlash)
+      }
     }
+  }
+
   var capturedDevices: NSMutableArray?
   var previewLayer: AVCaptureVideoPreviewLayer?
   weak var delegate: CameraViewDelegate?

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -4,6 +4,7 @@ import AssetsLibrary
 
 protocol CameraViewDelegate: class {
 
+  func setFlashButtonHidden(hidden: Bool)
   func handleFlashButton(hide: Bool)
   func imageToLibrary()
 }
@@ -49,7 +50,13 @@ class CameraView: UIViewController {
 
   let captureSession = AVCaptureSession()
   let devices = AVCaptureDevice.devices()
-  var captureDevice: AVCaptureDevice?
+    var captureDevice: AVCaptureDevice? {
+        didSet {
+            if let currentDevice = captureDevice {
+              delegate?.setFlashButtonHidden(!currentDevice.hasFlash)
+            }
+        }
+    }
   var capturedDevices: NSMutableArray?
   var previewLayer: AVCaptureVideoPreviewLayer?
   weak var delegate: CameraViewDelegate?

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -228,13 +228,6 @@ extension ImagePickerController: CameraViewDelegate {
     topView.flashButton.hidden = hidden
   }
 
-  func handleFlashButton(hide: Bool) {
-    let alpha: CGFloat = hide ? 0 : 1
-    UIView.animateWithDuration(0.3) {
-      self.topView.flashButton.alpha = alpha
-    }
-  }
-
   func imageToLibrary() {
     galleryView.fetchPhotos() {
       guard let asset = self.galleryView.assets.first else { return }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -224,6 +224,10 @@ extension ImagePickerController: BottomContainerViewDelegate {
 
 extension ImagePickerController: CameraViewDelegate {
 
+  func setFlashButtonHidden(hidden: Bool) {
+    topView.flashButton.hidden = hidden
+  }
+
   func handleFlashButton(hide: Bool) {
     let alpha: CGFloat = hide ? 0 : 1
     UIView.animateWithDuration(0.3) {

--- a/Source/TopView/TopView.swift
+++ b/Source/TopView/TopView.swift
@@ -67,25 +67,28 @@ class TopView: UIView {
   func flashButtonDidPress(button: UIButton) {
     guard let currentTitle = button.currentTitle else { return }
 
+    var newTitle = ""
+
     switch currentTitle {
     case "AUTO":
+      newTitle = "ON"
       button.setImage(getImage("flashIcon"), forState: .Normal)
       button.setTitleColor(UIColor(red:0.98, green:0.98, blue:0.45, alpha:1), forState: .Normal)
       button.setTitleColor(UIColor(red:0.52, green:0.52, blue:0.24, alpha:1), forState: .Highlighted)
-      button.setTitle("ON", forState: .Normal)
     case "ON":
+      newTitle = "OFF"
       button.setImage(getImage("flashIconOn"), forState: .Normal)
       button.setTitleColor(.whiteColor(), forState: .Normal)
       button.setTitleColor(.whiteColor(), forState: .Highlighted)
-      button.setTitle("OFF", forState: .Normal)
     case "OFF":
+      newTitle = "AUTO"
       button.setImage(getImage("flashIcon"), forState: .Normal)
-      button.setTitle("AUTO", forState: .Normal)
     default:
       break
     }
 
-    delegate?.flashButtonDidPress(currentTitle)
+    button.setTitle(newTitle, forState: .Normal)
+    delegate?.flashButtonDidPress(newTitle)
   }
 
   func rotateCameraButtonDidPress(button: UIButton) {


### PR DESCRIPTION
I fixed a crash when user may tap "flash" button on device which has no flash.
For example, it happened to me on iPad 3.
I didn't check for `front/back` camera switch as all devices that support iOS 8+ have 2 cameras.
This is how it looks on iPad:
![img_0214](https://cloud.githubusercontent.com/assets/8013017/10297111/2c333b84-6bcf-11e5-9f24-bb5a41ed0960.jpg)
