### PR TITLE
Feature loading indicator

### DIFF
--- a/Demo/ImagePickerDemo/ImagePickerDemo.xcodeproj/project.pbxproj
+++ b/Demo/ImagePickerDemo/ImagePickerDemo.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		29D699E91B70ABFC0021FA73 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 29D699E71B70ABFC0021FA73 /* LaunchScreen.xib */; };
 		29D699F51B70ABFC0021FA73 /* ImagePickerDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D699F41B70ABFC0021FA73 /* ImagePickerDemoTests.swift */; };
 		29D699FF1B70ACD50021FA73 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 29D699FE1B70ACD50021FA73 /* Podfile */; };
-		C3771E008DA39CF04754C8A9 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733A7AD0105A657A80502E72 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C3771E008DA39CF04754C8A9 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733A7AD0105A657A80502E72 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/Demo/ImagePickerDemo/Podfile.lock
+++ b/Demo/ImagePickerDemo/Podfile.lock
@@ -6,9 +6,9 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   ImagePicker:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   ImagePicker: 32becfa25b8e9179e60c45411b577340d35e3e32
 
-COCOAPODS: 0.39.0.beta.4
+COCOAPODS: 0.39.0

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -66,9 +66,9 @@ public class BottomContainerView: UIView {
   public override init(frame: CGRect) {
     super.init(frame: frame)
 
-    for view in [borderPickerButton, pickerButton, doneButton, stackView, topSeparator] {
-      addSubview(view)
-      view.translatesAutoresizingMaskIntoConstraints = false
+    [borderPickerButton, pickerButton, doneButton, stackView, topSeparator].forEach {
+      addSubview($0)
+      $0.translatesAutoresizingMaskIntoConstraints = false
     }
 
     backgroundColor = pickerConfiguration.backgroundColor

--- a/Source/BottomView/StackView.swift
+++ b/Source/BottomView/StackView.swift
@@ -166,7 +166,6 @@ extension ImageStackView {
     UIView.animateWithDuration(0.3, animations: {
       imageView.transform = CGAffineTransformMakeScale(1.05, 1.05)
       }) { _ in
-
         UIView.animateWithDuration(0.2, animations: { () -> Void in
           self.activityView.alpha = 0.0
           imageView.transform = CGAffineTransformIdentity

--- a/Source/BottomView/StackView.swift
+++ b/Source/BottomView/StackView.swift
@@ -16,6 +16,7 @@ class ImageStackView: UIView {
   lazy var activityView: UIActivityIndicatorView = {
     let view = UIActivityIndicatorView()
     view.alpha = 0.0
+
     return view
     }()
 

--- a/Source/BottomView/StackView.swift
+++ b/Source/BottomView/StackView.swift
@@ -13,6 +13,12 @@ class ImageStackView: UIView {
 
   weak var delegate: ImageStackViewDelegate?
 
+  lazy var activityView: UIActivityIndicatorView = {
+    let view = UIActivityIndicatorView()
+    view.alpha = 0.0
+    return view
+    }()
+
   var views: [UIImageView] = {
     var array = [UIImageView]()
     for i in 0...3 {
@@ -35,11 +41,9 @@ class ImageStackView: UIView {
 
     subscribe()
 
-    for view in views {
-      addSubview(view)
-    }
-    
-    views[0].alpha = 1
+    views.forEach { addSubview($0) }
+    addSubview(activityView)
+    views.first?.alpha = 1
     layoutSubviews()
   }
 
@@ -85,12 +89,23 @@ class ImageStackView: UIView {
       view.frame = CGRect(origin: origin, size: viewSize)
     }
   }
+
+  func startLoader() {
+    if let firstVisibleView = views.filter({ $0.alpha == 1.0 }).last {
+      activityView.frame.origin.x = firstVisibleView.center.x
+      activityView.frame.origin.y = firstVisibleView.center.y
+    }
+  
+    activityView.startAnimating()
+    UIView.animateWithDuration(0.3) {
+      self.activityView.alpha = 1.0
+    }
+  }
 }
 
 extension ImageStackView {
 
   func imageDidPush(notification: NSNotification) {
-
     //TODO indexOf in swift 2
     let emptyView = views.filter {$0.image == nil}.first
 
@@ -100,12 +115,14 @@ extension ImageStackView {
 
     if let sender = notification.object as? ImageStack {
       renderViews(sender.assets)
+      activityView.stopAnimating()
     }
   }
 
   func imageStackDidChangeContent(notification: NSNotification) {
     if let sender = notification.object as? ImageStack {
       renderViews(sender.assets)
+      activityView.stopAnimating()
     }
   }
 
@@ -132,6 +149,13 @@ extension ImageStackView {
         view.image = nil
         view.alpha = 0
       }
+
+      if index == photos.count {
+        UIView.animateWithDuration(0.3) {
+          self.activityView.frame.origin.x = view.center.x + 3
+          self.activityView.frame.origin.y = view.center.y + 3
+        }
+      }
     }
   }
 
@@ -141,9 +165,13 @@ extension ImageStackView {
     UIView.animateWithDuration(0.3, animations: {
       imageView.transform = CGAffineTransformMakeScale(1.05, 1.05)
       }) { _ in
-        UIView.animateWithDuration(0.2) { _ in
+
+        UIView.animateWithDuration(0.2, animations: { () -> Void in
+          self.activityView.alpha = 0.0
           imageView.transform = CGAffineTransformIdentity
-        }
+          }, completion: { _ in
+            self.activityView.stopAnimating()
+        })
     }
   }
 }

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -99,9 +99,7 @@ public class ImageGalleryView: UIView {
     collectionView.registerClass(ImageGalleryViewCell.self,
       forCellWithReuseIdentifier: CollectionView.reusableIdentifier)
 
-    for view in [collectionView, topSeparator] {
-      addSubview(view)
-    }
+    [collectionView, topSeparator].forEach { addSubview($0) }
 
     topSeparator.addSubview(indicator)
     imagesBeforeLoading = 0

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -212,6 +212,7 @@ public class ImagePickerController: UIViewController {
 extension ImagePickerController: BottomContainerViewDelegate {
 
   func pickerButtonDidPress() {
+    bottomContainer.stackView.startLoader()
     collapseGalleryView { [unowned self] in
       self.cameraController.takePicture()
     }


### PR DESCRIPTION
The process of fetching images from the library is doing asynchronously and can be a bit slow if you take a rapid series of images.

To work around this issue, this PR adds an `UIActivityIndicatorView` that adds on top of the image stack to indicate that the devices is loading photos.

![img_0329](https://cloud.githubusercontent.com/assets/57446/11093593/68fc1378-888b-11e5-8c0a-ed627b3f32db.PNG)
![img_0335](https://cloud.githubusercontent.com/assets/57446/11093598/6c385c5e-888b-11e5-8f78-3d6bb3ad10c4.PNG)

