### PR TITLE
Update noImagesLabel 

### DIFF
--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -124,8 +124,18 @@ public class ImageGalleryView: UIView {
       width: Dimensions.indicatorWidth, height: Dimensions.indicatorHeight)
     collectionView.frame = CGRect(x: 0, y: topSeparator.frame.height, width: totalWidth, height: collectionFrame - topSeparator.frame.height)
     collectionSize = CGSize(width: collectionView.frame.height, height: collectionView.frame.height)
-    noImagesLabel.center = collectionView.center
+
+    updateNoImagesLabel()
   }
+
+  func updateNoImagesLabel() {
+    let height = CGRectGetHeight(bounds)
+    let threshold = Dimensions.galleryBarHeight * 2
+
+    noImagesLabel.center = CGPoint(x: CGRectGetWidth(bounds)/2, y: height/2)
+    noImagesLabel.alpha = (height > threshold) ? 1 : (height - Dimensions.galleryBarHeight) / threshold
+  }
+
 
   // MARK: - Photos handler
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -195,7 +195,8 @@ public class ImagePickerController: UIViewController {
     let constant = maximum ? GestureConstants.maximumHeight : GestureConstants.minimumHeight
     galleryView.collectionView.frame.size.height = constant - galleryView.topSeparator.frame.height
     galleryView.collectionSize = CGSize(width: galleryView.collectionView.frame.height, height: galleryView.collectionView.frame.height)
-    galleryView.noImagesLabel.center = galleryView.collectionView.center
+
+    galleryView.updateNoImagesLabel()
   }
 
   func enableGestures(enabled: Bool) {
@@ -334,7 +335,7 @@ extension ImagePickerController: ImageGalleryPanGestureDelegate {
       galleryView.frame.size.height = initialFrame.height - translation.y
     }
 
-    galleryView.noImagesLabel.center = galleryView.collectionView.center
+    galleryView.updateNoImagesLabel()
   }
 
   func panGestureDidEnd(translation: CGPoint, velocity: CGPoint) {


### PR DESCRIPTION
In case of no images available on the phone, `noImagesLabel` displays in wrong position. So

- Update `noImagesLabel`based on `ImageGalleryView` bounds, not `collectionView.center`. See http://stackoverflow.com/questions/29528643/why-do-layer-transforms-affect-a-uiviews-frame
- Animate `noImagesLabel` alpha change if user is about to drag down the `ImageGalleryView`