### PR TITLE
Method 'cancelButtonDidPress()' with Objective-C selector 'cancelButtonDidPress' conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ presentViewController(imagePickerController, animated: true, completion: nil)
 **ImagePicker** has three delegate methods that will inform you what the users are up to:
 
 ```swift
-func wrapperDidPress(images: [UIImage])
-func doneButtonDidPress(images: [UIImage])
-func cancelButtonDidPress()
+func imagePickerWrapperDidPress(images: [UIImage])
+func imagePickerDoneButtonDidPress(images: [UIImage])
+func imagePickerCancelButtonDidPress()
 ```
 
 **ImagePicker** supports limiting the amount of images that can be selected, it defaults

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -3,8 +3,8 @@ import MediaPlayer
 
 public protocol ImagePickerDelegate: class {
 
-  func wrapperDidPress(images: [UIImage])
-  func doneButtonDidPress(images: [UIImage])
+  func imagePickerWrapperDidPress(images: [UIImage])
+  func imagePickerDoneButtonDidPress(images: [UIImage])
   func imagePickerCancelButtonDidPress()
 }
 
@@ -260,7 +260,7 @@ extension ImagePickerController: BottomContainerViewDelegate {
 
   func doneButtonDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
-    delegate?.doneButtonDidPress(images)
+    delegate?.imagePickerDoneButtonDidPress(images)
   }
 
   func cancelButtonDidPress() {
@@ -270,7 +270,7 @@ extension ImagePickerController: BottomContainerViewDelegate {
 
   func imageStackViewDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
-    delegate?.wrapperDidPress(images)
+    delegate?.imagePickerWrapperDidPress(images)
   }
 }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -5,7 +5,7 @@ public protocol ImagePickerDelegate: class {
 
   func wrapperDidPress(images: [UIImage])
   func doneButtonDidPress(images: [UIImage])
-  func cancelButtonDidPress()
+  func imagePickerCancelButtonDidPress()
 }
 
 public class ImagePickerController: UIViewController {
@@ -265,7 +265,7 @@ extension ImagePickerController: BottomContainerViewDelegate {
 
   func cancelButtonDidPress() {
     dismissViewControllerAnimated(true, completion: nil)
-    delegate?.cancelButtonDidPress()
+    delegate?.imagePickerCancelButtonDidPress()
   }
 
   func imageStackViewDidPress() {


### PR DESCRIPTION
Method 'cancelButtonDidPress()' with Objective-C selector 'cancelButtonDidPress' conflicts with method 'cancelButtonDidPress()' from superclass 'ImagePickerController' with the same Objective-C selector