### PR TITLE
Fix bug where pictures are repeatedly taken due to new AVCaptureSessi…

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -169,7 +169,11 @@ public class ImagePickerController: UIViewController {
   }
 
   func volumeChanged(notification: NSNotification) {
-    guard let slider = volumeView.subviews.filter({ $0 is UISlider }).first as? UISlider else { return }
+    guard let slider = volumeView.subviews.filter({ $0 is UISlider }).first as? UISlider,
+      let userInfo = notification.userInfo,
+      let changeReason = userInfo["AVSystemController_AudioVolumeChangeReasonNotificationParameter"] as? String
+      where changeReason == "ExplicitVolumeChange" else { return }
+    
     slider.setValue(volume, animated: false)
     cameraController.takePicture()
   }


### PR DESCRIPTION
Experienced a bug where snapping a picture would result in an endless loop of new pictures being snapped. Traced it back to the volumeChanged function being repeatedly called, likely due to AVSystemController_SystemVolumeDidChangeNotification notifications being sent whenever a new AVCapture session is initiated. Refer to [this Stack Overflow thread](http://stackoverflow.com/questions/13799740/avsystemcontroller-systemvolumedidchangenotification-on-iphone-5).