### PR TITLE
Record location with CLLocationManager if permission given by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ imagePickerController.imageLimit = 5
 
 ##### Configuration
 
-Configure text, colors and fonts by just overriding the static variables in the ImagePicker [configuration](https://github.com/hyperoslo/ImagePicker/blob/master/Source/Configuration.swift) struct. As an example:
+Configure text, colors, fonts and camera features by just overriding the static variables in the ImagePicker [configuration](https://github.com/hyperoslo/ImagePicker/blob/master/Source/Configuration.swift) struct. As an example:
 
 ```swift
 Configuration.doneButtonTitle = "Finish"

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -401,22 +401,22 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
 }
 
 class LocationManager: NSObject, CLLocationManagerDelegate {
-  var clManager = CLLocationManager()
+  var locationManager = CLLocationManager()
   var latestLocation: CLLocation?
 
   override init() {
     super.init()
-    clManager.delegate = self
-    clManager.desiredAccuracy = kCLLocationAccuracyBest
-    clManager.requestWhenInUseAuthorization()
+    locationManager.delegate = self
+    locationManager.desiredAccuracy = kCLLocationAccuracyBest
+    locationManager.requestWhenInUseAuthorization()
   }
 
   func startUpdatingLocation() {
-    clManager.startUpdatingLocation()
+    locationManager.startUpdatingLocation()
   }
 
   func stopUpdatingLocation() {
-    clManager.stopUpdatingLocation()
+    locationManager.stopUpdatingLocation()
   }
 
   // MARK: - CLLocationManagerDelegate
@@ -428,12 +428,9 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
 
   func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
     if status == .AuthorizedAlways || status == .AuthorizedWhenInUse {
-      clManager.startUpdatingLocation()
+      locationManager.startUpdatingLocation()
     } else {
-      clManager.stopUpdatingLocation()
+      locationManager.stopUpdatingLocation()
     }
-  }
-
-  func locationManager(manager: CLLocationManager, didFailWithError error: NSError) {
   }
 }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -265,6 +265,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
 
           PHPhotoLibrary.sharedPhotoLibrary().performChanges({
             let request = PHAssetChangeRequest.creationRequestForAssetFromImage(imageFromData)
+            request.creationDate = NSDate()
             request.location = self.locationManager?.latestLocation
           }, completionHandler:  { success, error in
             self.delegate?.imageToLibrary()

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -32,7 +32,7 @@ public struct Configuration {
   public static var cellSpacing: CGFloat = 2
     
   // MARK: Custom behaviour
-
-  public static var canRotateCamera: Bool = true
+  
   public static var collapseCollectionViewWhileShot: Bool = true
+  public static var recordLocation: Bool = true
 }

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -32,6 +32,7 @@ public struct Configuration {
   public static var cellSpacing: CGFloat = 2
     
   // MARK: Custom behaviour
-  
-    public static var collapseCollectionViewWhileShot: Bool = true
+
+  public static var canRotateCamera: Bool = true
+  public static var collapseCollectionViewWhileShot: Bool = true
 }

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -33,6 +33,7 @@ public struct Configuration {
     
   // MARK: Custom behaviour
   
+  public static var canRotateCamera: Bool = true
   public static var collapseCollectionViewWhileShot: Bool = true
   public static var recordLocation: Bool = true
 }

--- a/Source/Extensions/ConstraintsSetup.swift
+++ b/Source/Extensions/ConstraintsSetup.swift
@@ -74,22 +74,24 @@ extension TopView {
     addConstraint(NSLayoutConstraint(item: flashButton, attribute: .Width,
       relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
       multiplier: 1, constant: 55))
+    
+    if Configuration.canRotateCamera {
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Right,
+        relatedBy: .Equal, toItem: self, attribute: .Right,
+        multiplier: 1, constant: Dimensions.rightOffset))
 
-    addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Right,
-      relatedBy: .Equal, toItem: self, attribute: .Right,
-      multiplier: 1, constant: Dimensions.rightOffset))
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .CenterY,
+        relatedBy: .Equal, toItem: self, attribute: .CenterY,
+        multiplier: 1, constant: 0))
 
-    addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .CenterY,
-      relatedBy: .Equal, toItem: self, attribute: .CenterY,
-      multiplier: 1, constant: 0))
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Width,
+        relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+        multiplier: 1, constant: 55))
 
-    addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Width,
-      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
-      multiplier: 1, constant: 55))
-
-    addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Height,
-      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
-      multiplier: 1, constant: 55))
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Height,
+        relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+        multiplier: 1, constant: 55))
+    }
   }
 }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -262,7 +262,7 @@ public class ImagePickerController: UIViewController {
     bottomContainer.pickerButton.enabled = enabled
     bottomContainer.tapGestureRecognizer.enabled = enabled
     topView.flashButton.enabled = enabled
-    topView.rotateCamera.enabled = enabled
+    topView.rotateCamera.enabled = Configuration.canRotateCamera
   }
 }
 

--- a/Source/TopView/TopView.swift
+++ b/Source/TopView/TopView.swift
@@ -46,8 +46,14 @@ class TopView: UIView {
 
   override init(frame: CGRect) {
     super.init(frame: frame)
+    
+    var buttons: [UIButton] = [flashButton]
 
-    for button in [flashButton, rotateCamera] {
+    if (Configuration.canRotateCamera) {
+        buttons.append(rotateCamera)
+    }
+    
+    for button in buttons {
       button.layer.shadowColor = UIColor.blackColor().CGColor
       button.layer.shadowOpacity = 0.5
       button.layer.shadowOffset = CGSize(width: 0, height: 1)


### PR DESCRIPTION
Here's a proposed fix for #102 which I posted the other day. Some notes about this solution:

- The `NSLocationWhenInUseUsageDescription` key in Info.plist must be set to whatever message should be displayed when requesting Location Services access from the user. If this key is not set, CLLocationManager will not attempt to fetch new locations.
- This solution doesn't write the GPS tag to the actual image file, but rather is stored via the PHPhotoLibrary API (in a separate DB I'm guessing). This means that accessing the image via the asset library always gives you access to the location, but if you only look at the image data itself it's not available. I had a solution actually writing the GPS tag too, but it was quite ugly since converting to UIImage drops any associated metadata. This led to a lot of marshalling between UIImage CGImage and NSData. Additionally, a separate fix was needed for iOS 8 which doesn't support creating image assets directly from data via PHAssetCreationRequest. This solution, however, is very straightforward and should work for both iOS 8 and 9.
- `startUpdatingLocation()` and `stopUpdatingLocation()` were used rather than `requestLocationUpdate()` in order to get a location fix more quickly.

As always, thanks for maintaining this project, and hoping this is helpful :)