### PR TITLE
Fix/image selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.2
+osx_image: xcode7.3
 language: objective-c
 
 before_install:

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -9,7 +9,11 @@ protocol BottomContainerViewDelegate: class {
 }
 
 public class BottomContainerView: UIView {
-
+  
+  struct Dimensions {
+    static let height: CGFloat = 101
+  }
+  
   lazy var pickerButton: ButtonPicker = { [unowned self] in
     let pickerButton = ButtonPicker()
     pickerButton.setTitleColor(.whiteColor(), forState: .Normal)

--- a/Source/Extensions/ConstraintsSetup.swift
+++ b/Source/Extensions/ConstraintsSetup.swift
@@ -123,7 +123,7 @@ extension ImagePickerController {
 
     view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: .Height,
       relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
-      multiplier: 1, constant: Dimensions.bottomContainerHeight))
+      multiplier: 1, constant: BottomContainerView.Dimensions.height))
 
     view.addConstraint(NSLayoutConstraint(item: topView, attribute: .Height,
       relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
@@ -131,7 +131,7 @@ extension ImagePickerController {
 
     view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: .Height,
       relatedBy: .Equal, toItem: view, attribute: .Height,
-      multiplier: 1, constant: -Dimensions.bottomContainerHeight))
+      multiplier: 1, constant: -BottomContainerView.Dimensions.height))
   }
 }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -192,18 +192,6 @@ public class ImagePickerController: UIViewController {
 
   // MARK: - Helpers
 
-  public override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-
-    let galleryHeight: CGFloat = UIScreen.mainScreen().nativeBounds.height == 960
-      ? ImageGalleryView.Dimensions.galleryBarHeight
-      : GestureConstants.minimumHeight
-
-    let y = totalSize.height - bottomContainer.frame.height - galleryHeight
-    galleryView.frame = CGRect(x: 0, y: y,
-      width: totalSize.width, height: galleryHeight)
-  }
-
   public override func prefersStatusBarHidden() -> Bool {
     return true
   }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -249,14 +249,6 @@ public class ImagePickerController: UIViewController {
     galleryView.frame.size.height = constant
   }
 
-  func updateCollectionViewFrames(maximum: Bool) {
-    let constant = maximum ? GestureConstants.maximumHeight : GestureConstants.minimumHeight
-    galleryView.collectionView.frame.size.height = constant - galleryView.topSeparator.frame.height
-    galleryView.collectionSize = CGSize(width: galleryView.collectionView.frame.height, height: galleryView.collectionView.frame.height)
-
-    galleryView.updateNoImagesLabel()
-  }
-
   func enableGestures(enabled: Bool) {
     galleryView.alpha = enabled ? 1 : 0
     bottomContainer.pickerButton.enabled = enabled

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -10,9 +10,7 @@ public protocol ImagePickerDelegate: class {
 
 public class ImagePickerController: UIViewController {
 
-  struct Dimensions {
-    static let bottomContainerHeight: CGFloat = 101
-  }
+  
 
   struct GestureConstants {
     static let maximumHeight: CGFloat = 200


### PR DESCRIPTION
When we select an image in galleryView, `viewWillLayoutSubviews` gets called and sets the frame again.
The problem is the gallery view gets moved down, as in this gif

![untitled](https://cloud.githubusercontent.com/assets/2284279/14105436/d4b03710-f5ab-11e5-98c6-75185f293dbd.gif)

@RamonGilabert does `viewWillLayoutSubviews` exist for some purpose?
