### PR TITLE
Fix Image Limit bug

### DIFF
--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -237,7 +237,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     }
   }
 
-  func takePicture(completion: Bool -> ()) {
+  func takePicture(completion: () -> ()) {
     capturedImageView.frame = view.bounds
 
     UIView.animateWithDuration(0.1, animations: {
@@ -269,7 +269,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
             request.location = self.locationManager?.latestLocation
           }, completionHandler:  { success, error in
             self.delegate?.imageToLibrary()
-            completion(true)
+            completion()
           })
       })
     })

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -237,7 +237,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     }
   }
 
-  func takePicture() {
+  func takePicture(completion: Bool -> ()) {
     capturedImageView.frame = view.bounds
 
     UIView.animateWithDuration(0.1, animations: {
@@ -269,6 +269,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
             request.location = self.locationManager?.latestLocation
           }, completionHandler:  { success, error in
             self.delegate?.imageToLibrary()
+            completion(true)
           })
       })
     })

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -9,7 +9,7 @@ public protocol ImagePickerDelegate: class {
 }
 
 public class ImagePickerController: UIViewController {
-  
+
   struct GestureConstants {
     static let maximumHeight: CGFloat = 200
     static let minimumHeight: CGFloat = 125
@@ -108,7 +108,7 @@ public class ImagePickerController: UIViewController {
 
   public override func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
-    
+
     statusBarHidden = UIApplication.sharedApplication().statusBarHidden
     UIApplication.sharedApplication().setStatusBarHidden(true, withAnimation: .Fade)
   }
@@ -249,9 +249,7 @@ public class ImagePickerController: UIViewController {
     bottomContainer.pickerButton.enabled = false
     bottomContainer.stackView.startLoader()
     let action: Void -> Void = { [unowned self] in
-      self.cameraController.takePicture({ (finished) in
-        self.isTakingPicture = false
-      })
+      self.cameraController.takePicture { self.isTakingPicture = false }
     }
 
     if Configuration.collapseCollectionViewWhileShot {
@@ -269,7 +267,7 @@ extension ImagePickerController: BottomContainerViewDelegate {
   func pickerButtonDidPress() {
     takePicture()
   }
-  
+
   func doneButtonDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
     delegate?.doneButtonDidPress(images)

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -74,6 +74,7 @@ public class ImagePickerController: UIViewController {
   var numberOfCells: Int?
   var statusBarHidden = true
 
+  private var isTakingPicture = false
   public var doneButtonTitle: String? {
     didSet {
       if let doneButtonTitle = doneButtonTitle {
@@ -174,7 +175,7 @@ public class ImagePickerController: UIViewController {
       where changeReason == "ExplicitVolumeChange" else { return }
 
     slider.setValue(volume, animated: false)
-    cameraController.takePicture()
+    takePicture()
   }
 
   func adjustButtonTitle(notification: NSNotification) {
@@ -237,19 +238,20 @@ public class ImagePickerController: UIViewController {
     topView.flashButton.enabled = enabled
     topView.rotateCamera.enabled = Configuration.canRotateCamera
   }
-}
 
-// MARK: - Action methods
+  private func isBelowImageLimit() -> Bool {
+    return (imageLimit == 0 || imageLimit > galleryView.selectedStack.assets.count)
+    }
 
-extension ImagePickerController: BottomContainerViewDelegate {
-
-  func pickerButtonDidPress() {
-    guard imageLimit == 0 || imageLimit > galleryView.selectedStack.assets.count else { return }
-
+  private func takePicture() {
+    guard isBelowImageLimit() && !isTakingPicture else { return }
+    isTakingPicture = true
     bottomContainer.pickerButton.enabled = false
     bottomContainer.stackView.startLoader()
     let action: Void -> Void = { [unowned self] in
-      self.cameraController.takePicture()
+      self.cameraController.takePicture({ (finished) in
+        self.isTakingPicture = false
+      })
     }
 
     if Configuration.collapseCollectionViewWhileShot {
@@ -258,7 +260,16 @@ extension ImagePickerController: BottomContainerViewDelegate {
       action()
     }
   }
+}
 
+// MARK: - Action methods
+
+extension ImagePickerController: BottomContainerViewDelegate {
+
+  func pickerButtonDidPress() {
+    takePicture()
+  }
+  
   func doneButtonDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
     delegate?.doneButtonDidPress(images)


### PR DESCRIPTION
@zenangst 

Fixes following bug from #103 
`2. While taking pictures using button to change volume ImagesPicker ignores imageLimit`

Also i found following new, undocumented bug, which is also fixed.
`While taking Photo from Volume button, event  gets fired multiple times triggering image bursts`