### PR TITLE
Fix frame for NoImage Label

### DIFF
--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -104,7 +104,7 @@ public class ImageGalleryView: UIView {
     [collectionView, topSeparator].forEach { addSubview($0) }
 
     topSeparator.addSubview(indicator)
-    
+
     imagesBeforeLoading = 0
     fetchPhotos()
   }
@@ -122,6 +122,7 @@ public class ImageGalleryView: UIView {
 
   func updateFrames() {
     let totalWidth = UIScreen.mainScreen().bounds.width
+    frame.size.width = totalWidth
     let collectionFrame = frame.height == Dimensions.galleryBarHeight ? 100 + Dimensions.galleryBarHeight : frame.height
     topSeparator.frame = CGRect(x: 0, y: 0, width: totalWidth, height: Dimensions.galleryBarHeight)
     topSeparator.autoresizingMask = [.FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleWidth]


### PR DESCRIPTION
Corrects this following special case.

This happens in landscape mode. Where `No Images available` label is not centred.

![simulator screen shot 02-apr-2016 8 58 33 pm](https://cloud.githubusercontent.com/assets/1090001/14227216/f718cb9c-f915-11e5-9a3c-7a3492bb8846.png)

to
![simulator screen shot 02-apr-2016 9 01 17 pm](https://cloud.githubusercontent.com/assets/1090001/14227220/13a1defc-f916-11e5-8925-b934c610471a.png)
