### PR TITLE
Refactored ImageGalleryPanGestureDelegate

### DIFF
--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -6,10 +6,6 @@ protocol ImageGalleryPanGestureDelegate: class {
   func panGestureDidStart()
   func panGestureDidChange(translation: CGPoint)
   func panGestureDidEnd(translation: CGPoint, velocity: CGPoint)
-  func presentViewController(controller: UIAlertController)
-  func dismissViewController(controller: UIAlertController)
-  func permissionGranted()
-  func hideViews()
 }
 
 public class ImageGalleryView: UIView {
@@ -177,40 +173,6 @@ public class ImageGalleryView: UIView {
   func displayNoImagesMessage(hideCollectionView: Bool) {
     collectionView.alpha = hideCollectionView ? 0 : 1
     updateNoImagesLabel()
-  }
-
-  func checkStatus() {
-    let currentStatus = PHPhotoLibrary.authorizationStatus()
-
-    guard currentStatus != .Authorized else { return }
-
-    if currentStatus == .NotDetermined {
-      delegate?.hideViews()
-    }
-
-    PHPhotoLibrary.requestAuthorization { (authorizationStatus) -> Void in
-      dispatch_async(dispatch_get_main_queue(), {
-        if authorizationStatus == .Denied {
-          let alertController = UIAlertController(title: "Permission denied", message: "Please, allow the application to access to your photo library.", preferredStyle: .Alert)
-
-          let alertAction = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default) { _ in
-            if let settingsURL = NSURL(string: UIApplicationOpenSettingsURLString) {
-              UIApplication.sharedApplication().openURL(settingsURL)
-            }
-          }
-
-          let cancelAction = UIAlertAction(title: "Cancel", style: UIAlertActionStyle.Cancel) { _ in
-            self.delegate?.dismissViewController(alertController)
-          }
-
-          alertController.addAction(alertAction)
-          alertController.addAction(cancelAction)
-          self.delegate?.presentViewController(alertController)
-        } else if authorizationStatus == .Authorized {
-          self.delegate?.permissionGranted()
-        }
-      })
-    }
   }
 }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MediaPlayer
+import Photos
 
 public protocol ImagePickerDelegate: class {
 
@@ -121,7 +122,7 @@ public class ImagePickerController: UIViewController {
     galleryView.frame = CGRectMake(0, totalSize.height - bottomContainer.frame.height - galleryHeight,
       totalSize.width, galleryHeight)
     galleryView.updateFrames()
-    galleryView.checkStatus()
+    checkStatus()
 
     initialFrame = galleryView.frame
     initialContentOffset = galleryView.collectionView.contentOffset
@@ -130,6 +131,53 @@ public class ImagePickerController: UIViewController {
   public override func viewWillDisappear(animated: Bool) {
     super.viewWillDisappear(animated)
     UIApplication.sharedApplication().setStatusBarHidden(statusBarHidden, withAnimation: .Fade)
+  }
+
+  func checkStatus() {
+    let currentStatus = PHPhotoLibrary.authorizationStatus()
+    guard currentStatus != .Authorized else { return }
+
+    if currentStatus == .NotDetermined { hideViews() }
+
+    PHPhotoLibrary.requestAuthorization { (authorizationStatus) -> Void in
+      dispatch_async(dispatch_get_main_queue(), {
+        if authorizationStatus == .Denied {
+          self.presentAskPermissionAlert()
+        } else if authorizationStatus == .Authorized {
+          self.permissionGranted()
+        }
+      })
+    }
+  }
+
+  func presentAskPermissionAlert() {
+    let alertController = UIAlertController(title: "Permission denied", message: "Please, allow the application to access to your photo library.", preferredStyle: .Alert)
+
+    let alertAction = UIAlertAction(title: "OK", style: .Default) { _ in
+      if let settingsURL = NSURL(string: UIApplicationOpenSettingsURLString) {
+        UIApplication.sharedApplication().openURL(settingsURL)
+      }
+    }
+
+    let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) { _ in
+      self.dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    alertController.addAction(alertAction)
+    alertController.addAction(cancelAction)
+
+    presentViewController(alertController, animated: true, completion: nil)
+  }
+
+  func hideViews() {
+    enableGestures(false)
+  }
+
+  func permissionGranted() {
+    galleryView.fetchPhotos()
+    galleryView.canFetchImages = false
+    cameraController.initializeCamera()
+    enableGestures(true)
   }
 
   // MARK: - Notifications
@@ -315,25 +363,6 @@ extension ImagePickerController: TopViewDelegate {
 // MARK: - Pan gesture handler
 
 extension ImagePickerController: ImageGalleryPanGestureDelegate {
-
-  func hideViews() {
-    enableGestures(false)
-  }
-
-  func permissionGranted() {
-    galleryView.fetchPhotos()
-    galleryView.canFetchImages = false
-    cameraController.initializeCamera()
-    enableGestures(true)
-  }
-
-  func presentViewController(controller: UIAlertController) {
-    presentViewController(controller, animated: true, completion: nil)
-  }
-
-  func dismissViewController(controller: UIAlertController) {
-    dismissViewControllerAnimated(true, completion: nil)
-  }
 
   func panGestureDidStart() {
     guard let collectionSize = galleryView.collectionSize else { return }


### PR DESCRIPTION
Refactors code a little bit. The original implementation had 2 issues. 

1. `ImageGalleryPanGestureDelegate ` had following functions 

```
- func presentViewController(controller: UIAlertController)
-  func dismissViewController(controller: UIAlertController)
-  func permissionGranted()
-  func hideViews()
```

These should not fall under `ImageGalleryPanGestureDelegate`.

2.  It is not responsibility of `ImageGalleryView ` to call `PHPhotoLibrary.requestAuthorization`...violates `MVC` in my point of view.