### PR TITLE
Fix UI when Camera access is denied.

### DIFF
--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -61,7 +61,11 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
       ])
 
     button.setAttributedTitle(title, forState: .Normal)
+    button.contentEdgeInsets = UIEdgeInsetsMake(5.0, 10.0, 5.0, 10.0)
     button.sizeToFit()
+    button.layer.borderColor = Configuration.settingsColor.CGColor
+    button.layer.borderWidth = 1
+    button.layer.cornerRadius = 4
     button.addTarget(self, action: #selector(settingsButtonDidTap), forControlEvents: .TouchUpInside)
 
     return button
@@ -122,7 +126,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     let centerX = view.bounds.width / 2
 
     noCameraLabel.center = CGPoint(x: centerX,
-      y: view.bounds.height / 2 - 100)
+      y: view.bounds.height / 2 - 80)
 
     noCameraButton.center = CGPoint(x: centerX,
       y: noCameraLabel.frame.maxY + 20)

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -17,7 +17,7 @@ public struct Configuration {
   public static var flashButton = UIFont(name: "HelveticaNeue-Medium", size: 12)!
   public static var noImagesFont = UIFont(name: "HelveticaNeue-Medium", size: 18)!
   public static var noCameraFont = UIFont(name: "HelveticaNeue-Medium", size: 18)!
-  public static var settingsFont = UIFont(name: "HelveticaNeue-Medium", size: 18)!
+  public static var settingsFont = UIFont(name: "HelveticaNeue-Medium", size: 16)!
 
   // MARK: Titles
 


### PR DESCRIPTION
Makes Following tiny improvement in UI.

1. When Camera access is denied, `Settings` button looks like just a label. Improving its presentation. 

![image-one](https://cloud.githubusercontent.com/assets/1090001/14308373/56135682-fbf3-11e5-8c41-304f6e59f3f3.png)

2. In Landscape mode label is way too up, touching the top.

![image-two](https://cloud.githubusercontent.com/assets/1090001/14308463/f585aa08-fbf3-11e5-9bbc-4f388b60fd04.png)
