### PR TITLE
Remove sessionPreset

### DIFF
--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -131,7 +131,6 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
   // MARK: - Initialize camera
 
   func initializeCamera() {
-    captureSession.sessionPreset = AVCaptureSessionPreset1920x1080
     capturedDevices = NSMutableArray()
 
     showNoCamera(false)
@@ -195,18 +194,13 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     self.captureDevice = capturedDevices?.objectAtIndex(newDeviceIndex) as? AVCaptureDevice
     configureDevice()
 
-    guard let currentCaptureDevice = self.captureDevice else { return }
+    guard let _ = self.captureDevice else { return }
+
     UIView.animateWithDuration(0.3, animations: { [unowned self] in
       self.containerView.alpha = 1
       }, completion: { finished in
         self.captureSession.beginConfiguration()
         self.captureSession.removeInput(currentDeviceInput)
-
-        self.captureSession.sessionPreset =
-          currentCaptureDevice.supportsAVCaptureSessionPreset(AVCaptureSessionPreset1280x720)
-          ? AVCaptureSessionPreset1280x720
-          : AVCaptureSessionPreset640x480
-
         do { try
           self.captureSession.addInput(AVCaptureDeviceInput(device: self.captureDevice))
         } catch {


### PR DESCRIPTION
This should fix issue  #124. But i do not have iPad 2 to test. May be you guys can help here @zenangst 

We should avoid using these sessionPreset `AVCaptureSessionPreset1280x720` `AVCaptureSessionPreset1920x1080 ` `AVCaptureSessionPreset640x480 `.
We better use `AVCaptureSessionPresetHigh` if we are trying to capture the best quality. Also `AVCaptureSessionPresetHigh` varies depending on the device.

Even more `AVCaptureSessionPresetHigh` is default value therefore no need to set either. 

In fact i am wondering was there a specific reason to use `AVCaptureSessionPreset1280x720` `AVCaptureSessionPreset1920x1080 ` `AVCaptureSessionPreset640x480 `? Am i missing something?