### PR TITLE
Call reloadData after updating collectionSize

### DIFF
--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -130,6 +130,8 @@ public class ImageGalleryView: UIView {
       width: Dimensions.indicatorWidth, height: Dimensions.indicatorHeight)
     collectionView.frame = CGRect(x: 0, y: topSeparator.frame.height, width: totalWidth, height: collectionFrame - topSeparator.frame.height)
     collectionSize = CGSize(width: collectionView.frame.height, height: collectionView.frame.height)
+    
+    collectionView.reloadData()
   }
 
   func updateNoImagesLabel() {


### PR DESCRIPTION
In `ImageGalleryView.swift`, `fetchPhotos` finished and reloads before `collectionSize` gets determined. So call `reloadData` again after `collectionSize` gets determined. This should fix the problem of images not appear when opening ImagePicker

@zenangst FYI