### PR TITLE
Reset transform and contentInset just in case

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -119,6 +119,9 @@ public class ImagePickerController: UIViewController {
     let galleryHeight: CGFloat = UIScreen.mainScreen().nativeBounds.height == 960
       ? ImageGalleryView.Dimensions.galleryBarHeight : GestureConstants.minimumHeight
 
+    galleryView.collectionView.transform = CGAffineTransformIdentity
+    galleryView.collectionView.contentInset = UIEdgeInsetsZero
+    
     galleryView.frame = CGRectMake(0, totalSize.height - bottomContainer.frame.height - galleryHeight,
       totalSize.width, galleryHeight)
     galleryView.updateFrames()


### PR DESCRIPTION
There are cases an instance of ImagePicker is used and presented multiple times, but in `viewDidAppear` we reset its frame anyway, so now we reset the `transform` and `contentInset` also