### PR TITLE
Configure preset before addInput

### DIFF
--- a/Demo/ImagePickerDemo/Podfile.lock
+++ b/Demo/ImagePickerDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ImagePicker (1.2)
+  - ImagePicker (1.3)
   - MainThreadGuard (0.1.0)
 
 DEPENDENCIES:
@@ -18,7 +18,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/onmyway133/MainThreadGuard
 
 SPEC CHECKSUMS:
-  ImagePicker: 85f14ed6872f46c08d210077b5540a890a6cd151
+  ImagePicker: 667e68fdef7b08dcbb5879e410b37f331f82fc3e
   MainThreadGuard: 401a64b400d749b41a9c1fe93086af05c3f33333
 
 COCOAPODS: 0.39.0

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -212,8 +212,9 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
       }, completion: { finished in
         self.captureSession.beginConfiguration()
         self.captureSession.removeInput(currentDeviceInput)
-        do { try
-          self.captureSession.addInput(AVCaptureDeviceInput(device: self.captureDevice))
+        do {
+          self.configurePreset()
+          try self.captureSession.addInput(AVCaptureDeviceInput(device: self.captureDevice))
         } catch {
           print("There was an error capturing your device.")
         }
@@ -341,8 +342,9 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     guard captureSession.inputs.count == 0 else { return }
 
     let captureDeviceInput: AVCaptureDeviceInput?
-    do { try
-      captureDeviceInput = AVCaptureDeviceInput(device: self.captureDevice)
+    do {
+      try captureDeviceInput = AVCaptureDeviceInput(device: self.captureDevice)
+      self.configurePreset()
       captureSession.addInput(captureDeviceInput)
     } catch {
       print("Failed to capture device")
@@ -393,5 +395,25 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     default:
       break
     }
+  }
+
+  // MARK: Preset
+  func configurePreset() {
+    guard let device = self.captureDevice else { return }
+
+    for preset in preferredPresets() {
+      if device.supportsAVCaptureSessionPreset(preset) && self.captureSession.canSetSessionPreset(preset) {
+        self.captureSession.sessionPreset = preset
+        return
+      }
+    }
+  }
+
+  func preferredPresets() -> [String] {
+    return [
+      AVCaptureSessionPresetHigh,
+      AVCaptureSessionPresetMedium,
+      AVCaptureSessionPresetLow
+    ]
   }
 }


### PR DESCRIPTION
I have this error in iPhone 5

```
Can't add <AVCaptureDeviceInput: 0x1724d560 [Front Camera]> because the device does not support AVCaptureSessionPreset1920x1080. Use -[AVCaptureDevice supportsAVCaptureSessionPreset:].
```

As you already know, the `AVCaptureSession` `sessionPreset` defaults to `AVCaptureSessionPresetHigh `. In iPhone 5, `AVCaptureSessionPresetHigh` means `1920x1080` for Back Camera and `1280x720` for Front Camera.

This maybe because when changing from Back to Front camera, `AVCaptureSessionPresetHigh` still means `1920x1080` for the Front Camera 🐼  !!! Maybe 😬 

So this fix always check and update `sessionPreset`