### PR TITLE
Use serial sessionQueue because most session calls are blocking

### DIFF
--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -71,6 +71,8 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     return button
     }()
 
+  let sessionQueue = dispatch_queue_create("no.hyper.ImagePicker.SessionQueue", dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_BACKGROUND, 0))
+
   let captureSession = AVCaptureSession()
   var devices = AVCaptureDevice.devices()
   var captureDevice: AVCaptureDevice? {
@@ -355,10 +357,13 @@ class CameraView: UIViewController, CLLocationManagerDelegate {
     view.layer.addSublayer(previewLayer)
     previewLayer.frame = view.layer.frame
     view.clipsToBounds = true
-    captureSession.startRunning()
-    stillImageOutput = AVCaptureStillImageOutput()
-    stillImageOutput?.outputSettings = [AVVideoCodecKey: AVVideoCodecJPEG]
-    captureSession.addOutput(stillImageOutput)
+
+    dispatch_async(sessionQueue) {
+      self.captureSession.startRunning()
+      self.stillImageOutput = AVCaptureStillImageOutput()
+      self.stillImageOutput?.outputSettings = [AVVideoCodecKey: AVVideoCodecJPEG]
+      self.captureSession.addOutput(self.stillImageOutput)
+    }
   }
 
   // MARK: - Private helpers


### PR DESCRIPTION
Especially `startRunning`

> The startRunning method is a blocking call which can take some time, therefore you should perform session setup on a serial queue so that the main queue isn't blocked (which keeps the UI responsive). See AVCam-iOS: Using AVFoundation to Capture Images and Movies for an implementation example.