### PR TITLE
Improvements

### DIFF
--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -4,7 +4,7 @@ import PhotosUI
 
 protocol CameraManDelegate: class {
   func cameraManNotAvailable(cameraMan: CameraMan)
-  func cameraManWillStart(cameraMan: CameraMan)
+  func cameraManDidStart(cameraMan: CameraMan)
   func cameraMan(cameraMan: CameraMan, didChangeInput input: AVCaptureDeviceInput)
 }
 
@@ -108,12 +108,12 @@ class CameraMan {
       session.addOutput(output)
     }
 
-    dispatch_async(dispatch_get_main_queue()) {
-      self.delegate?.cameraManWillStart(self)
-    }
-
     dispatch_async(queue) {
       self.session.startRunning()
+
+      dispatch_async(dispatch_get_main_queue()) {
+        self.delegate?.cameraManDidStart(self)
+      }
     }
   }
 

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -6,6 +6,7 @@ protocol CameraViewDelegate: class {
 
   func setFlashButtonHidden(hidden: Bool)
   func imageToLibrary()
+  func cameraNotAvailable()
 }
 
 class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate {
@@ -267,6 +268,8 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
   // CameraManDelegate
   func cameraManNotAvailable(cameraMan: CameraMan) {
     showNoCamera(true)
+    focusImageView.hidden = true
+    delegate?.cameraNotAvailable()
   }
 
   func cameraMan(cameraMan: CameraMan, didChangeInput input: AVCaptureDeviceInput) {

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -284,7 +284,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     delegate?.setFlashButtonHidden(!input.device.hasFlash)
   }
 
-  func cameraManWillStart(cameraMan: CameraMan) {
+  func cameraManDidStart(cameraMan: CameraMan) {
     setupPreviewLayer()
   }
 }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -72,6 +72,12 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     return button
     }()
 
+  lazy var tapGestureRecognizer: UITapGestureRecognizer = { [unowned self] in
+    let gesture = UITapGestureRecognizer()
+    gesture.addTarget(self, action: #selector(tapGestureRecognizerHandler(_:)))
+
+    return gesture
+    }()
 
   let cameraMan = CameraMan()
 
@@ -95,6 +101,8 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     [focusImageView, capturedImageView].forEach {
       view.addSubview($0)
     }
+
+    view.addGestureRecognizer(tapGestureRecognizer)
 
     cameraMan.delegate = self
     cameraMan.setup()
@@ -221,14 +229,14 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     })
   }
 
-  override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
-    guard let firstTouch = touches.first else { return }
-    let anyTouch = firstTouch
-    let touchX = anyTouch.locationInView(view).x
-    let touchY = anyTouch.locationInView(view).y
+  // MARK: - Tap
+
+  func tapGestureRecognizerHandler(gesture: UITapGestureRecognizer) {
+    let touch = gesture.locationInView(view)
+
     focusImageView.transform = CGAffineTransformIdentity
     animationTimer?.invalidate()
-    focusTo(CGPointMake(touchX, touchY))
+    focusTo(touch)
   }
 
   // MARK: - Private helpers

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -102,7 +102,7 @@ public class ImagePickerController: UIViewController {
 
     cameraController.view.addGestureRecognizer(panGestureRecognizer)
 
-    try! AVAudioSession.sharedInstance().setActive(true)
+    try? AVAudioSession.sharedInstance().setActive(true)
 
     subscribe()
     setupConstraints()
@@ -187,7 +187,7 @@ public class ImagePickerController: UIViewController {
   // MARK: - Notifications
 
   deinit {
-    try! AVAudioSession.sharedInstance().setActive(false)
+    try? AVAudioSession.sharedInstance().setActive(false)
     NSNotificationCenter.defaultCenter().removeObserver(self)
   }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -356,6 +356,12 @@ extension ImagePickerController: CameraViewDelegate {
         self.galleryView.collectionView.transform = CGAffineTransformIdentity
     }
   }
+
+  func cameraNotAvailable() {
+    topView.flashButton.hidden = true
+    topView.rotateCamera.hidden = true
+    bottomContainer.pickerButton.enabled = false
+  }
 }
 
 // MARK: - TopView delegate methods

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -99,6 +99,7 @@ public class ImagePickerController: UIViewController {
 
     view.backgroundColor = .whiteColor()
     view.backgroundColor = Configuration.mainColor
+
     cameraController.view.addGestureRecognizer(panGestureRecognizer)
 
     try! AVAudioSession.sharedInstance().setActive(true)


### PR DESCRIPTION
- Use try? instead of try!
- Use tapGestureRecognizer instead of touchBegan, so that when we pan the focus indicator does not show up
- Wait for startRunning to complete before init preview layer, which makes preview layer shows up much faster
- Disable camera related buttons when camera is not available. Hide flash and switch camera button, disable shutter button in this case