### PR TITLE
Dismiss Picker View controller on Done Button tap

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -324,6 +324,7 @@ extension ImagePickerController: BottomContainerViewDelegate {
   func doneButtonDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
     delegate?.doneButtonDidPress(images)
+    dismissViewControllerAnimated(true, completion: nil)
   }
 
   func cancelButtonDidPress() {


### PR DESCRIPTION
Whats new in the pull request?
![one](https://cloud.githubusercontent.com/assets/1090001/15661022/41ee5eca-2701-11e6-886b-199551f3aa45.png)

the bottom right button has two states - Cancel and Done.

Cancel, when no image is selected.
Done, when some images are selected.

When you tap on Cancel button picker gets dismissed but this does not happen when you tap on Done button. This is not an expected behaviour. 

Although i am not sure if this behaviour was intentional. 



