### PR TITLE
Added convenience function to reset image stack

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -140,6 +140,10 @@ public class ImagePickerController: UIViewController {
     UIApplication.sharedApplication().setStatusBarHidden(statusBarHidden, withAnimation: .Fade)
   }
 
+  public func resetAssets() {
+    self.stack.resetAssets([])
+  }
+
   func checkStatus() {
     let currentStatus = PHPhotoLibrary.authorizationStatus()
     guard currentStatus != .Authorized else { return }


### PR DESCRIPTION
Whats new in this pull request?

This provides a convenience function to reset image stack. This will solve issue #70 .
Although same thing can be achieved via `picker.stack.resetAssets([PHAsset]())` as @richardoti  suggested, but then i think that is not a good way. Now you can do only `picker.resetAssets()`