### PR TITLE
Refactored Deletgate method names

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -4,9 +4,9 @@ import Photos
 
 public protocol ImagePickerDelegate: class {
 
-  func wrapperDidPress(images: [UIImage])
-  func doneButtonDidPress(images: [UIImage])
-  func cancelButtonDidPress()
+  func wrapperDidPress(imagePicker: ImagePickerController, images: [UIImage])
+  func doneButtonDidPress(imagePicker: ImagePickerController, images: [UIImage])
+  func cancelButtonDidPress(imagePicker: ImagePickerController)
 }
 
 public class ImagePickerController: UIViewController {
@@ -323,17 +323,17 @@ extension ImagePickerController: BottomContainerViewDelegate {
 
   func doneButtonDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
-    delegate?.doneButtonDidPress(images)
+    delegate?.doneButtonDidPress(self, images: images)
   }
 
   func cancelButtonDidPress() {
     dismissViewControllerAnimated(true, completion: nil)
-    delegate?.cancelButtonDidPress()
+    delegate?.cancelButtonDidPress(self)
   }
 
   func imageStackViewDidPress() {
     let images = ImagePicker.resolveAssets(stack.assets)
-    delegate?.wrapperDidPress(images)
+    delegate?.wrapperDidPress(self, images: images)
   }
 }
 


### PR DESCRIPTION
Whats new in this pull request?

This refactors method definition of ImagePickerDelegate. While creating delegates it is common practice to return the owner. For example look at the documentation of `UIImagePickerControllerDelegate ` [here ](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImagePickerControllerDelegate_Protocol/). Every delegate method return `UIImagePickerController`.

This refactoring also solves issue #154