### PR TITLE
Move top and bottom bars to the sides for compact heights.

### DIFF
--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -73,7 +73,6 @@ public class BottomContainerView: UIView {
     backgroundColor = Configuration.backgroundColor
     stackView.addGestureRecognizer(tapGestureRecognizer)
 
-    setupConstraints()
   }
 
   public required init?(coder aDecoder: NSCoder) {

--- a/Source/Extensions/ConstraintsSetup.swift
+++ b/Source/Extensions/ConstraintsSetup.swift
@@ -4,20 +4,23 @@ import UIKit
 
 extension BottomContainerView {
 
-  func setupConstraints() {
+  func setupConstraints(compactHeight: Bool) {
+    removeConstraints(constraints)
+    setupCommonConstraints()
+    if compactHeight {
+      setupCompactHeightConstraints()
+    } else {
+      setupRegularHeightConstraints()
+    }
+  }
 
+  func setupCommonConstraints() {
     for attribute: NSLayoutAttribute in [.CenterX, .CenterY] {
       addConstraint(NSLayoutConstraint(item: pickerButton, attribute: attribute,
         relatedBy: .Equal, toItem: self, attribute: attribute,
         multiplier: 1, constant: 0))
 
       addConstraint(NSLayoutConstraint(item: borderPickerButton, attribute: attribute,
-        relatedBy: .Equal, toItem: self, attribute: attribute,
-        multiplier: 1, constant: 0))
-    }
-
-    for attribute: NSLayoutAttribute in [.Width, .Left, .Top] {
-      addConstraint(NSLayoutConstraint(item: topSeparator, attribute: attribute,
         relatedBy: .Equal, toItem: self, attribute: attribute,
         multiplier: 1, constant: 0))
     }
@@ -34,6 +37,14 @@ extension BottomContainerView {
       addConstraint(NSLayoutConstraint(item: stackView, attribute: attribute,
         relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
         multiplier: 1, constant: ImageStackView.Dimensions.imageSize))
+    }
+  }
+
+  func setupRegularHeightConstraints() {
+    for attribute: NSLayoutAttribute in [.Width, .Left, .Top] {
+      addConstraint(NSLayoutConstraint(item: topSeparator, attribute: attribute,
+        relatedBy: .Equal, toItem: self, attribute: attribute,
+        multiplier: 1, constant: 0))
     }
 
     addConstraint(NSLayoutConstraint(item: doneButton, attribute: .CenterY,
@@ -55,6 +66,35 @@ extension BottomContainerView {
     addConstraint(NSLayoutConstraint(item: topSeparator, attribute: .Height,
       relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
       multiplier: 1, constant: 1))
+
+  }
+
+  func setupCompactHeightConstraints() {
+    for attribute: NSLayoutAttribute in [.Height, .Left, .Top] {
+      addConstraint(NSLayoutConstraint(item: topSeparator, attribute: attribute,
+        relatedBy: .Equal, toItem: self, attribute: attribute,
+        multiplier: 1, constant: 0))
+    }
+
+    addConstraint(NSLayoutConstraint(item: doneButton, attribute: .CenterX,
+      relatedBy: .Equal, toItem: self, attribute: .CenterX,
+      multiplier: 1, constant: 0))
+
+    addConstraint(NSLayoutConstraint(item: stackView, attribute: .CenterX,
+      relatedBy: .Equal, toItem: self, attribute: .CenterX,
+      multiplier: 1, constant: -2))
+
+    addConstraint(NSLayoutConstraint(item: doneButton, attribute: .CenterY,
+      relatedBy: .Equal, toItem: self, attribute: .Bottom,
+      multiplier: 1, constant: -(UIScreen.mainScreen().bounds.height - (ButtonPicker.Dimensions.buttonBorderSize + UIScreen.mainScreen().bounds.height)/2)/2))
+
+    addConstraint(NSLayoutConstraint(item: stackView, attribute: .CenterY,
+      relatedBy: .Equal, toItem: self, attribute: .Top,
+      multiplier: 1, constant: UIScreen.mainScreen().bounds.height/4 - ButtonPicker.Dimensions.buttonBorderSize/3))
+
+    addConstraint(NSLayoutConstraint(item: topSeparator, attribute: .Width,
+      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+      multiplier: 1, constant: 1))
   }
 }
 
@@ -62,7 +102,56 @@ extension BottomContainerView {
 
 extension TopView {
 
-  func setupConstraints() {
+  func setupConstraints(compactHeight: Bool) {
+    removeConstraints(constraints)
+    setupCommonConstraints()
+    if compactHeight {
+      setupCompactHeightConstraints()
+    } else {
+      setupRegularHeightConstraints()
+    }
+  }
+
+  func setupCommonConstraints() {
+    addConstraint(NSLayoutConstraint(item: flashButton, attribute: .Width,
+      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+      multiplier: 1, constant: 55))
+
+    if Configuration.canRotateCamera {
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Width,
+        relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+        multiplier: 1, constant: 55))
+
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Height,
+        relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+        multiplier: 1, constant: 55))
+    }
+
+  }
+
+  func setupCompactHeightConstraints() {
+    addConstraint(NSLayoutConstraint(item: flashButton, attribute: .Left,
+      relatedBy: .Equal, toItem: self, attribute: .Left,
+      multiplier: 1, constant: 8))
+
+    addConstraint(NSLayoutConstraint(item: flashButton, attribute: .Top,
+      relatedBy: .Equal, toItem: self, attribute: .Top,
+      multiplier: 1, constant: 6))
+
+    if Configuration.canRotateCamera {
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Bottom,
+        relatedBy: .Equal, toItem: self, attribute: .Bottom,
+        multiplier: 1, constant: Dimensions.rightOffset))
+
+      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .CenterX,
+        relatedBy: .Equal, toItem: self, attribute: .CenterX,
+        multiplier: 1, constant: 0))
+
+    }
+
+  }
+
+  func setupRegularHeightConstraints() {
     addConstraint(NSLayoutConstraint(item: flashButton, attribute: .Left,
       relatedBy: .Equal, toItem: self, attribute: .Left,
       multiplier: 1, constant: Dimensions.leftOffset))
@@ -70,10 +159,6 @@ extension TopView {
     addConstraint(NSLayoutConstraint(item: flashButton, attribute: .CenterY,
       relatedBy: .Equal, toItem: self, attribute: .CenterY,
       multiplier: 1, constant: 0))
-
-    addConstraint(NSLayoutConstraint(item: flashButton, attribute: .Width,
-      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
-      multiplier: 1, constant: 55))
 
     if Configuration.canRotateCamera {
       addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Right,
@@ -83,14 +168,6 @@ extension TopView {
       addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .CenterY,
         relatedBy: .Equal, toItem: self, attribute: .CenterY,
         multiplier: 1, constant: 0))
-
-      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Width,
-        relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
-        multiplier: 1, constant: 55))
-
-      addConstraint(NSLayoutConstraint(item: rotateCamera, attribute: .Height,
-        relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
-        multiplier: 1, constant: 55))
     }
   }
 }
@@ -99,25 +176,36 @@ extension TopView {
 
 extension ImagePickerController {
 
-  func setupConstraints() {
-    let attributes: [NSLayoutAttribute] = [.Bottom, .Right, .Width]
-    let topViewAttributes: [NSLayoutAttribute] = [.Left, .Top, .Width]
-
-    for attribute in attributes {
-      view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: attribute,
-        relatedBy: .Equal, toItem: view, attribute: attribute,
-        multiplier: 1, constant: 0))
+  func setupConstraints(compactHeight: Bool) {
+    view.constraints.forEach() { constraint in
+      if constraint.firstItem as! NSObject == cameraController.view ||
+        constraint.firstItem as! NSObject == bottomContainer ||
+        constraint.firstItem as! NSObject == topView
+      {
+        view.removeConstraint(constraint)
+      }
     }
+    if compactHeight {
+      setupCompactHeightConstraints()
+    } else {
+      setupRegularHeightConstraints()
+    }
+  }
 
+  func setupRegularHeightConstraints() {
     for attribute: NSLayoutAttribute in [.Left, .Top, .Width] {
       view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: attribute,
         relatedBy: .Equal, toItem: view, attribute: attribute,
         multiplier: 1, constant: 0))
     }
 
-    for attribute in topViewAttributes {
-      view.addConstraint(NSLayoutConstraint(item: topView, attribute: attribute,
-        relatedBy: .Equal, toItem: self.view, attribute: attribute,
+    view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: .Height,
+      relatedBy: .Equal, toItem: view, attribute: .Height,
+      multiplier: 1, constant: -BottomContainerView.Dimensions.height))
+
+    for attribute: NSLayoutAttribute in [.Bottom, .Right, .Width] {
+      view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: attribute,
+        relatedBy: .Equal, toItem: view, attribute: attribute,
         multiplier: 1, constant: 0))
     }
 
@@ -125,14 +213,51 @@ extension ImagePickerController {
       relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
       multiplier: 1, constant: BottomContainerView.Dimensions.height))
 
+    for attribute: NSLayoutAttribute in [.Left, .Top, .Width] {
+      view.addConstraint(NSLayoutConstraint(item: topView, attribute: attribute,
+        relatedBy: .Equal, toItem: self.view, attribute: attribute,
+        multiplier: 1, constant: 0))
+    }
+
     view.addConstraint(NSLayoutConstraint(item: topView, attribute: .Height,
       relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
       multiplier: 1, constant: TopView.Dimensions.height))
 
-    view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: .Height,
-      relatedBy: .Equal, toItem: view, attribute: .Height,
-      multiplier: 1, constant: -BottomContainerView.Dimensions.height))
   }
+
+  func setupCompactHeightConstraints() {
+
+    for attribute: NSLayoutAttribute in [.Left, .Top, .Height] {
+      view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: attribute,
+        relatedBy: .Equal, toItem: view, attribute: attribute,
+        multiplier: 1, constant: 0))
+    }
+
+    view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: .Width,
+      relatedBy: .Equal, toItem: view, attribute: .Width,
+      multiplier: 1, constant: -BottomContainerView.Dimensions.height))
+
+    for attribute: NSLayoutAttribute in [.Top, .Right, .Height] {
+      view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: attribute,
+        relatedBy: .Equal, toItem: view, attribute: attribute,
+        multiplier: 1, constant: 0))
+    }
+
+    view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: .Width,
+      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+      multiplier: 1, constant: BottomContainerView.Dimensions.height))
+
+    for attribute: NSLayoutAttribute in [.Left, .Top, .Height] {
+      view.addConstraint(NSLayoutConstraint(item: topView, attribute: attribute,
+        relatedBy: .Equal, toItem: self.view, attribute: attribute,
+        multiplier: 1, constant: 0))
+    }
+
+    view.addConstraint(NSLayoutConstraint(item: topView, attribute: .Width,
+      relatedBy: .Equal, toItem: nil, attribute: .NotAnAttribute,
+      multiplier: 1, constant: TopView.Dimensions.height))
+  }
+
 }
 
 extension ImageGalleryViewCell {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -103,13 +103,13 @@ public class ImagePickerController: UIViewController {
     cameraController.view.addGestureRecognizer(panGestureRecognizer)
 
     subscribe()
-    setupConstraints()
   }
 
   public override func viewWillAppear(animated: Bool) {
     super.viewWillAppear(animated)
 
     _ = try? AVAudioSession.sharedInstance().setActive(true)
+    setupConstraintsForAllViews(traitCollection.verticalSizeClass == .Compact)
 
     statusBarHidden = UIApplication.sharedApplication().statusBarHidden
     UIApplication.sharedApplication().setStatusBarHidden(true, withAnimation: .Fade)
@@ -188,6 +188,25 @@ public class ImagePickerController: UIViewController {
     galleryView.fetchPhotos()
     galleryView.canFetchImages = false
     enableGestures(true)
+  }
+
+  public override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+    super.willTransitionToTraitCollection(newCollection, withTransitionCoordinator: coordinator)
+    coordinator.animateAlongsideTransition(
+      { context in
+        self.setupConstraintsForAllViews(newCollection.verticalSizeClass == .Compact)
+      },
+      completion: nil)
+
+  }
+
+  func setupConstraintsForAllViews(compactHeight: Bool) {
+    setupConstraints(compactHeight)
+    bottomContainer.setupConstraints(compactHeight)
+    topView.setupConstraints(compactHeight)
+//    self.view.setNeedsLayout()
+//    self.bottomContainer.setNeedsLayout()
+//    self.cameraController.view.setNeedsLayout()
   }
 
   // MARK: - Notifications
@@ -284,8 +303,13 @@ public class ImagePickerController: UIViewController {
   }
 
   func updateGalleryViewFrames(constant: CGFloat) {
-    galleryView.frame.origin.y = totalSize.height - bottomContainer.frame.height - constant
-    galleryView.frame.size.height = constant
+    if view.traitCollection.verticalSizeClass == .Compact {
+      // Don't show the gallery when we have a compact (phone landscape) height
+      galleryView.frame.size.height = 0
+    } else {
+      galleryView.frame.origin.y = totalSize.height - bottomContainer.frame.height - constant
+      galleryView.frame.size.height = constant
+    }
   }
 
   func enableGestures(enabled: Bool) {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -204,9 +204,6 @@ public class ImagePickerController: UIViewController {
     setupConstraints(compactHeight)
     bottomContainer.setupConstraints(compactHeight)
     topView.setupConstraints(compactHeight)
-//    self.view.setNeedsLayout()
-//    self.bottomContainer.setNeedsLayout()
-//    self.cameraController.view.setNeedsLayout()
   }
 
   // MARK: - Notifications

--- a/Source/TopView/TopView.swift
+++ b/Source/TopView/TopView.swift
@@ -62,7 +62,6 @@ class TopView: UIView {
       addSubview(button)
     }
 
-    setupConstraints()
   }
 
   required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
When faced with a compact height size class (landscape mode
in phones) the bottom bar blocks a large portion of the screen
and makes it very difficult to take pictures.

This commit detects the current vertical size class, and if it
is compact, moves the bottom and top bars to the side, which is
in line with the way the iPhone's camera app works

![img_0564](https://cloud.githubusercontent.com/assets/2799/17070413/c7ca0dfe-5029-11e6-8ff0-f1ce201666ff.PNG)
