### PR TITLE
Handle rotation

### DIFF
--- a/Demo/ImagePickerDemo/ImagePickerDemo.xcodeproj/project.pbxproj
+++ b/Demo/ImagePickerDemo/ImagePickerDemo.xcodeproj/project.pbxproj
@@ -152,7 +152,6 @@
 				TargetAttributes = {
 					29D699D81B70ABFC0021FA73 = {
 						CreatedOnToolsVersion = 6.4;
-						DevelopmentTeam = LG4DBY4QF9;
 					};
 				};
 			};

--- a/ImagePicker.xcodeproj/project.pbxproj
+++ b/ImagePicker.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		39D134101CAC4B4E00EA2ECE /* AssetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1340F1CAC4B4E00EA2ECE /* AssetManager.swift */; };
 		39E3C3311CAFD79200340DAD /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E3C3301CAFD79200340DAD /* LocationManager.swift */; };
 		D20FF6361CD23426000F3BFE /* CameraMan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FF6351CD23426000F3BFE /* CameraMan.swift */; };
+		D25A8C2C1D47681E0008D2F7 /* ImageGalleryLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25A8C2B1D47681E0008D2F7 /* ImageGalleryLayout.swift */; };
+		D25A8C2E1D4768250008D2F7 /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25A8C2D1D4768250008D2F7 /* Helper.swift */; };
 		D5D370C01C44FD1600690C0A /* AUTO@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5D370BA1C44FD1600690C0A /* AUTO@3x.png */; };
 		D5D370C11C44FD1600690C0A /* cameraIcon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5D370BB1C44FD1600690C0A /* cameraIcon@3x.png */; };
 		D5D370C21C44FD1600690C0A /* focusIcon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5D370BC1C44FD1600690C0A /* focusIcon@3x.png */; };
@@ -46,6 +48,8 @@
 		39D1340F1CAC4B4E00EA2ECE /* AssetManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetManager.swift; sourceTree = "<group>"; };
 		39E3C3301CAFD79200340DAD /* LocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		D20FF6351CD23426000F3BFE /* CameraMan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraMan.swift; sourceTree = "<group>"; };
+		D25A8C2B1D47681E0008D2F7 /* ImageGalleryLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageGalleryLayout.swift; sourceTree = "<group>"; };
+		D25A8C2D1D4768250008D2F7 /* Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
 		D5D370BA1C44FD1600690C0A /* AUTO@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AUTO@3x.png"; sourceTree = "<group>"; };
 		D5D370BB1C44FD1600690C0A /* cameraIcon@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cameraIcon@3x.png"; sourceTree = "<group>"; };
 		D5D370BC1C44FD1600690C0A /* focusIcon@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "focusIcon@3x.png"; sourceTree = "<group>"; };
@@ -145,6 +149,7 @@
 		D5DC59AA1C201CC4003BD79B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				D25A8C2D1D4768250008D2F7 /* Helper.swift */,
 				D5DC59AC1C201CC4003BD79B /* BottomView */,
 				D5DC59B11C201CC4003BD79B /* CameraView */,
 				D5DC59B31C201CC4003BD79B /* Configuration.swift */,
@@ -189,6 +194,7 @@
 		D5DC59B61C201CC4003BD79B /* ImageGallery */ = {
 			isa = PBXGroup;
 			children = (
+				D25A8C2B1D47681E0008D2F7 /* ImageGalleryLayout.swift */,
 				D5DC59B71C201CC4003BD79B /* ImageGalleryView.swift */,
 				D5DC59B81C201CC4003BD79B /* ImageGalleryViewCell.swift */,
 				D5DC59B91C201CC4003BD79B /* ImageGalleryViewDataSource.swift */,
@@ -338,9 +344,11 @@
 				D5DC59C41C201CC4003BD79B /* ImageStack.swift in Sources */,
 				39E3C3311CAFD79200340DAD /* LocationManager.swift in Sources */,
 				D5DC59CB1C201CC4003BD79B /* ImageGalleryViewDataSource.swift in Sources */,
+				D25A8C2C1D47681E0008D2F7 /* ImageGalleryLayout.swift in Sources */,
 				D5DC59CA1C201CC4003BD79B /* ImageGalleryViewCell.swift in Sources */,
 				D5DC59C81C201CC4003BD79B /* ConstraintsSetup.swift in Sources */,
 				D5DC59C71C201CC4003BD79B /* Configuration.swift in Sources */,
+				D25A8C2E1D4768250008D2F7 /* Helper.swift in Sources */,
 				39D134101CAC4B4E00EA2ECE /* AssetManager.swift in Sources */,
 				D5DC59C21C201CC4003BD79B /* BottomContainerView.swift in Sources */,
 				D5DC59CC1C201CC4003BD79B /* ImagePickerController.swift in Sources */,

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -247,13 +247,6 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     }
   }
 
-  override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-    super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-
-    previewLayer?.frame.size = size
-    setCorrectOrientationToPreviewLayer()
-  }
-
   func setCorrectOrientationToPreviewLayer() {
     guard let previewLayer = self.previewLayer,
       connection = previewLayer.connection

--- a/Source/Helper.swift
+++ b/Source/Helper.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+struct Helper {
+
+  static func rotationTransform() -> CGAffineTransform {
+    switch UIDevice.currentDevice().orientation {
+    case .LandscapeLeft:
+      return CGAffineTransformMakeRotation(CGFloat(M_PI_2))
+    case .LandscapeRight:
+      return CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
+    case .PortraitUpsideDown:
+      return CGAffineTransformMakeRotation(CGFloat(M_PI))
+    default:
+      return CGAffineTransformIdentity
+    }
+  }
+}

--- a/Source/ImageGallery/ImageGalleryLayout.swift
+++ b/Source/ImageGallery/ImageGalleryLayout.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+class ImageGalleryLayout: UICollectionViewFlowLayout {
+
+  override func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+    let attributes = super.layoutAttributesForElementsInRect(rect)
+
+    let rotate: CGAffineTransform
+
+    switch UIDevice.currentDevice().orientation {
+    case .LandscapeLeft:
+      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
+    case .LandscapeRight:
+      rotate = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
+    case .PortraitUpsideDown:
+      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI))
+    default:
+      rotate = CGAffineTransformIdentity
+    }
+
+    attributes?.forEach {
+      $0.transform = rotate
+    }
+
+    return attributes
+  }
+}

--- a/Source/ImageGallery/ImageGalleryLayout.swift
+++ b/Source/ImageGallery/ImageGalleryLayout.swift
@@ -4,22 +4,9 @@ class ImageGalleryLayout: UICollectionViewFlowLayout {
 
   override func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
     let attributes = super.layoutAttributesForElementsInRect(rect)
-
-    let rotate: CGAffineTransform
-
-    switch UIDevice.currentDevice().orientation {
-    case .LandscapeLeft:
-      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
-    case .LandscapeRight:
-      rotate = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
-    case .PortraitUpsideDown:
-      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI))
-    default:
-      rotate = CGAffineTransformIdentity
-    }
-
+    
     attributes?.forEach {
-      $0.transform = rotate
+      $0.transform = Helper.rotationTransform()
     }
 
     return attributes

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -30,7 +30,7 @@ public class ImageGalleryView: UIView {
     }()
 
   lazy var collectionViewLayout: UICollectionViewLayout = { [unowned self] in
-    let layout = UICollectionViewFlowLayout()
+    let layout = ImageGalleryLayout()
     layout.scrollDirection = .Horizontal
     layout.minimumInteritemSpacing = Configuration.cellSpacing
     layout.minimumLineSpacing = 2

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -399,6 +399,7 @@ extension ImagePickerController: CameraViewDelegate {
       self.topView.rotateCamera.transform = rotate
       self.bottomContainer.pickerButton.transform = rotate
       self.bottomContainer.stackView.transform = rotate
+      self.galleryView.collectionViewLayout.invalidateLayout()
 
       let translate: CGAffineTransform
       if [UIDeviceOrientation.LandscapeLeft, UIDeviceOrientation.LandscapeRight]

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -382,21 +382,31 @@ extension ImagePickerController: CameraViewDelegate {
   }
 
   public func handleRotation(note: NSNotification) {
-    let transform: CGAffineTransform
+    let rotate: CGAffineTransform
 
     switch UIDevice.currentDevice().orientation {
     case .LandscapeLeft:
-      transform = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
+      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
     case .LandscapeRight:
-      transform = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
+      rotate = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
     case .PortraitUpsideDown:
-      transform = CGAffineTransformMakeRotation(CGFloat(M_PI))
+      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI))
     default:
-      transform = CGAffineTransformIdentity
+      rotate = CGAffineTransformIdentity
     }
 
     UIView.animateWithDuration(0.25) {
-      self.topView.rotateCamera.transform = transform
+      self.topView.rotateCamera.transform = rotate
+
+      let translate: CGAffineTransform
+      if [UIDeviceOrientation.LandscapeLeft, UIDeviceOrientation.LandscapeRight]
+        .contains(UIDevice.currentDevice().orientation) {
+        translate = CGAffineTransformMakeTranslation(-20, 15)
+      } else {
+        translate = CGAffineTransformIdentity
+      }
+
+      self.topView.flashButton.transform = CGAffineTransformConcat(rotate, translate)
     }
   }
 }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -397,6 +397,8 @@ extension ImagePickerController: CameraViewDelegate {
 
     UIView.animateWithDuration(0.25) {
       self.topView.rotateCamera.transform = rotate
+      self.bottomContainer.pickerButton.transform = rotate
+      self.bottomContainer.stackView.transform = rotate
 
       let translate: CGAffineTransform
       if [UIDeviceOrientation.LandscapeLeft, UIDeviceOrientation.LandscapeRight]

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -382,18 +382,7 @@ extension ImagePickerController: CameraViewDelegate {
   }
 
   public func handleRotation(note: NSNotification) {
-    let rotate: CGAffineTransform
-
-    switch UIDevice.currentDevice().orientation {
-    case .LandscapeLeft:
-      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
-    case .LandscapeRight:
-      rotate = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
-    case .PortraitUpsideDown:
-      rotate = CGAffineTransformMakeRotation(CGFloat(M_PI))
-    default:
-      rotate = CGAffineTransformIdentity
-    }
+    let rotate = Helper.rotationTransform()
 
     UIView.animateWithDuration(0.25) {
       self.topView.rotateCamera.transform = rotate

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -385,10 +385,11 @@ extension ImagePickerController: CameraViewDelegate {
     let rotate = Helper.rotationTransform()
 
     UIView.animateWithDuration(0.25) {
-      self.topView.rotateCamera.transform = rotate
-      self.bottomContainer.pickerButton.transform = rotate
-      self.bottomContainer.stackView.transform = rotate
-      self.bottomContainer.doneButton.transform = rotate
+      [self.topView.rotateCamera, self.bottomContainer.pickerButton,
+        self.bottomContainer.stackView, self.bottomContainer.doneButton].forEach {
+        $0.transform = rotate
+      }
+
       self.galleryView.collectionViewLayout.invalidateLayout()
 
       let translate: CGAffineTransform

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -388,6 +388,7 @@ extension ImagePickerController: CameraViewDelegate {
       self.topView.rotateCamera.transform = rotate
       self.bottomContainer.pickerButton.transform = rotate
       self.bottomContainer.stackView.transform = rotate
+      self.bottomContainer.doneButton.transform = rotate
       self.galleryView.collectionViewLayout.invalidateLayout()
 
       let translate: CGAffineTransform

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -369,6 +369,12 @@ extension ImagePickerController: CameraViewDelegate {
     topView.rotateCamera.hidden = true
     bottomContainer.pickerButton.enabled = false
   }
+
+  // MARK: - Rotation
+
+  public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
+    return .Portrait
+  }
 }
 
 // MARK: - TopView delegate methods

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -457,14 +457,4 @@ extension ImagePickerController: ImageGalleryPanGestureDelegate {
       collapseGalleryView(nil)
     }
   }
-
-  override public func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-    super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-
-    cameraController.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-    coordinator.animateAlongsideTransition({ (context) in
-      self.collapseGalleryView(nil)
-      self.galleryView.updateFrames()
-      }, completion: nil)
-  }
 }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -217,6 +217,11 @@ public class ImagePickerController: UIViewController {
       selector: #selector(volumeChanged(_:)),
       name: "AVSystemController_SystemVolumeDidChangeNotification",
       object: nil)
+
+    NSNotificationCenter.defaultCenter().addObserver(self,
+      selector: #selector(handleRotation(_:)),
+      name: UIDeviceOrientationDidChangeNotification,
+      object: nil)
   }
 
   func didReloadAssets(notification: NSNotification) {
@@ -374,6 +379,25 @@ extension ImagePickerController: CameraViewDelegate {
 
   public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
     return .Portrait
+  }
+
+  public func handleRotation(note: NSNotification) {
+    let transform: CGAffineTransform
+
+    switch UIDevice.currentDevice().orientation {
+    case .LandscapeLeft:
+      transform = CGAffineTransformMakeRotation(CGFloat(M_PI_2))
+    case .LandscapeRight:
+      transform = CGAffineTransformMakeRotation(CGFloat(-M_PI_2))
+    case .PortraitUpsideDown:
+      transform = CGAffineTransformMakeRotation(CGFloat(M_PI))
+    default:
+      transform = CGAffineTransformIdentity
+    }
+
+    UIView.animateWithDuration(0.25) {
+      self.topView.rotateCamera.transform = transform
+    }
   }
 }
 


### PR DESCRIPTION
This addresses issues https://github.com/hyperoslo/ImagePicker/issues/115, https://github.com/hyperoslo/ImagePicker/issues/183 and PR https://github.com/hyperoslo/ImagePicker/pull/182

- Lock view controller to portrait
- Rotate camera controls based on device orientation

PROS

- Easy to handle. The other approach is to rotate the camera along side with the device rotation, and adjust the transform to make some controls stay still, some rotate, which is tricky
- Looks similar to native camera behavior, although I don't know for sure if it really rotates or not
- In landscape, user can have more space for the camera preview, which is what he mostly intends to to

CONS

- `UIAlertController` is always portrait. But the UI in this case is really much portrait, so should be less surprise

![simulator screen shot 26 jul 2016 11 32 16](https://cloud.githubusercontent.com/assets/2284279/17133189/6990fe88-5325-11e6-8f11-b021a3c1f189.png)
