### PR TITLE
Fix asset

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -43,9 +43,10 @@ public class AssetManager {
   public static func resolveAsset(asset: PHAsset, size: CGSize = CGSize(width: 720, height: 1280), completion: (image: UIImage?) -> Void) {
     let imageManager = PHImageManager.defaultManager()
     let requestOptions = PHImageRequestOptions()
+    requestOptions.deliveryMode = .HighQualityFormat
 
     imageManager.requestImageForAsset(asset, targetSize: size, contentMode: .AspectFill, options: requestOptions) { image, info in
-      if let info = info where info["PHImageFileUTIKey"] == nil {
+      if let info = info {
         dispatch_async(dispatch_get_main_queue(), {
           completion(image: image)
         })

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -193,7 +193,7 @@ extension ImageGalleryView: UICollectionViewDelegate {
 
     let asset = assets[indexPath.row]
 
-    AssetManager.resolveAsset(asset) { image in
+    AssetManager.resolveAsset(asset, size: CGSize(width: 100, height: 100)) { image in
       guard let _ = image else { return }
 
       if cell.selectedImageView.image != nil {


### PR DESCRIPTION
- The default `deliveryMode` is `PHImageRequestOptionsDeliveryModeOpportunistic `

> If the synchronous property is NO, Photos may call the resultHandler block (that you specified in the requestImageForAsset:targetSize:contentMode:options:resultHandler: method **more than once**

which in some conditions, can call the callback twice.

- Also, reduce image size. As StackView does not need that large size