### PR TITLE
get rid of SwiftLint warnings

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 import Photos
-fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return l < r
@@ -12,7 +12,7 @@ fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
   }
 }
 
-fileprivate func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return l > r
@@ -62,7 +62,7 @@ open class AssetManager {
     requestOptions.deliveryMode = .highQualityFormat
 
     imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: requestOptions) { image, info in
-      if let info = info , info["PHImageFileUTIKey"] == nil {
+      if let info = info, info["PHImageFileUTIKey"] == nil {
         DispatchQueue.main.async(execute: {
           completion(image)
         })
@@ -83,7 +83,6 @@ open class AssetManager {
         }
       }
     }
-    
     return images
   }
 }

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -103,8 +103,8 @@ open class BottomContainerView: UIView {
       }, completion: { _ in
         UIView.animate(withDuration: 0.2, animations: { _ in
           imageView.transform = CGAffineTransform.identity
-        }) 
-    }) 
+        })
+    })
   }
 }
 

--- a/Source/BottomView/StackView.swift
+++ b/Source/BottomView/StackView.swift
@@ -99,7 +99,7 @@ class ImageStackView: UIView {
     activityView.startAnimating()
     UIView.animate(withDuration: 0.3, animations: {
       self.activityView.alpha = 1.0
-    }) 
+    })
   }
 }
 
@@ -126,8 +126,8 @@ extension ImageStackView {
   }
 
   func renderViews(_ assets: [PHAsset]) {
-    if let firstView = views.first , assets.isEmpty {
-      views.forEach{
+    if let firstView = views.first, assets.isEmpty {
+      views.forEach {
         $0.image = nil
         $0.alpha = 0
       }
@@ -152,7 +152,7 @@ extension ImageStackView {
       if index == photos.count {
         UIView.animate(withDuration: 0.3, animations: {
           self.activityView.frame.origin = CGPoint(x: view.center.x + 3, y: view.center.x + 3)
-        }) 
+        })
       }
     }
   }
@@ -169,6 +169,6 @@ extension ImageStackView {
           }, completion: { _ in
             self.activityView.stopAnimating()
         })
-    }) 
+    })
   }
 }

--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -187,7 +187,7 @@ class CameraMan {
   }
 
   func flash(_ mode: AVCaptureFlashMode) {
-    guard let device = currentInput?.device , device.isFlashModeSupported(mode) else { return }
+    guard let device = currentInput?.device, device.isFlashModeSupported(mode) else { return }
 
     queue.async {
       self.lock {
@@ -197,7 +197,7 @@ class CameraMan {
   }
 
   func focus(_ point: CGPoint) {
-    guard let device = currentInput?.device , device.isFocusModeSupported(AVCaptureFocusMode.locked) else { return }
+    guard let device = currentInput?.device, device.isFocusModeSupported(AVCaptureFocusMode.locked) else { return }
 
     queue.async {
       self.lock {
@@ -209,7 +209,7 @@ class CameraMan {
   // MARK: - Lock
 
   func lock(_ block: () -> Void) {
-    if let device = currentInput?.device , (try? device.lockForConfiguration()) != nil {
+    if let device = currentInput?.device, (try? device.lockForConfiguration()) != nil {
       block()
       device.unlockForConfiguration()
     }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -172,7 +172,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
         self.cameraMan.switchCamera {
           UIView.animate(withDuration: 0.7, animations: {
             self.containerView.alpha = 0
-          }) 
+          })
         }
     })
   }
@@ -194,7 +194,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
       }, completion: { _ in
         UIView.animate(withDuration: 0.1, animations: {
           self.capturedImageView.alpha = 0
-        }) 
+        })
     })
 
     cameraMan.takePhoto(previewLayer, location: locationManager?.latestLocation) {

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -43,13 +43,11 @@ public struct Configuration {
   public static var recordLocation = true
 
   // MARK: Images
-    
   public static var indicatorView: UIView = {
     let view = UIView()
     view.backgroundColor = UIColor.white.withAlphaComponent(0.6)
     view.layer.cornerRadius = 4
     view.translatesAutoresizingMaskIntoConstraints = false
-        
     return view
   }()
 }

--- a/Source/ImageGallery/ImageGalleryLayout.swift
+++ b/Source/ImageGallery/ImageGalleryLayout.swift
@@ -4,7 +4,6 @@ class ImageGalleryLayout: UICollectionViewFlowLayout {
 
   override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
     let attributes = super.layoutAttributesForElements(in: rect)
-    
     attributes?.forEach {
       $0.transform = Helper.rotationTransform()
     }

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Photos
-fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return l < r
@@ -141,7 +141,7 @@ open class ImageGalleryView: UIView {
         self.noImagesLabel.center = CGPoint(x: self.bounds.width / 2, y: height / 2)
         self.noImagesLabel.alpha = (height > threshold) ? 1 : (height - Dimensions.galleryBarHeight) / threshold
       }
-    }) 
+    })
   }
 
   // MARK: - Photos handler
@@ -212,14 +212,14 @@ extension ImageGalleryView: UICollectionViewDelegate {
           cell.selectedImageView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
           }, completion: { _ in
             cell.selectedImageView.image = nil
-        }) 
+        })
         self.selectedStack.dropAsset(asset)
       } else if self.imageLimit == 0 || self.imageLimit > self.selectedStack.assets.count {
         cell.selectedImageView.image = AssetManager.getImage("selectedImageGallery")
         cell.selectedImageView.transform = CGAffineTransform(scaleX: 0, y: 0)
         UIView.animate(withDuration: 0.2, animations: { _ in
           cell.selectedImageView.transform = CGAffineTransform.identity
-        }) 
+        })
         self.selectedStack.pushAsset(asset)
       }
     }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -236,8 +236,7 @@ open class ImagePickerController: UIViewController {
   func volumeChanged(_ notification: Notification) {
     guard let slider = volumeView.subviews.filter({ $0 is UISlider }).first as? UISlider,
       let userInfo = (notification as NSNotification).userInfo,
-      let changeReason = userInfo["AVSystemController_AudioVolumeChangeReasonNotificationParameter"] as? String
-      , changeReason == "ExplicitVolumeChange" else { return }
+      let changeReason = userInfo["AVSystemController_AudioVolumeChangeReasonNotificationParameter"] as? String, changeReason == "ExplicitVolumeChange" else { return }
 
     slider.setValue(volume, animated: false)
     takePicture()
@@ -253,7 +252,7 @@ open class ImagePickerController: UIViewController {
 
   // MARK: - Helpers
 
-  open override var prefersStatusBarHidden : Bool {
+  open override var prefersStatusBarHidden: Bool {
     return true
   }
 
@@ -265,7 +264,7 @@ open class ImagePickerController: UIViewController {
       self.galleryView.collectionView.contentInset = UIEdgeInsets.zero
       }, completion: { _ in
         completion?()
-    }) 
+    })
   }
 
   open func showGalleryView() {
@@ -381,7 +380,7 @@ extension ImagePickerController: CameraViewDelegate {
       self.galleryView.collectionView.transform = CGAffineTransform(translationX: collectionSize.width, y: 0)
       }, completion: { _ in
         self.galleryView.collectionView.transform = CGAffineTransform.identity
-    }) 
+    })
   }
 
   func cameraNotAvailable() {
@@ -392,7 +391,7 @@ extension ImagePickerController: CameraViewDelegate {
 
   // MARK: - Rotation
 
-  open override var supportedInterfaceOrientations : UIInterfaceOrientationMask {
+  open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     return .portrait
   }
 
@@ -416,7 +415,7 @@ extension ImagePickerController: CameraViewDelegate {
       }
 
       self.topView.flashButton.transform = rotate.concatenating(translate)
-    }) 
+    })
   }
 }
 
@@ -467,9 +466,7 @@ extension ImagePickerController: ImageGalleryPanGestureDelegate {
 
     if galleryHeight <= ImageGalleryView.Dimensions.galleryBarHeight {
       updateGalleryViewFrames(ImageGalleryView.Dimensions.galleryBarHeight)
-
     } else if galleryHeight >= GestureConstants.minimumHeight {
-
       let scale = (galleryHeight - ImageGalleryView.Dimensions.galleryBarHeight) / (GestureConstants.minimumHeight - ImageGalleryView.Dimensions.galleryBarHeight)
       galleryView.collectionView.transform = CGAffineTransform(scaleX: scale, y: scale)
       galleryView.frame.origin.y = initialFrame.origin.y + translation.y
@@ -477,9 +474,7 @@ extension ImagePickerController: ImageGalleryPanGestureDelegate {
 
       let value = view.frame.width * (scale - 1) / scale
       galleryView.collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right:  value)
-
     } else {
-
       galleryView.frame.origin.y = initialFrame.origin.y + translation.y
       galleryView.frame.size.height = initialFrame.height - translation.y
     }
@@ -489,9 +484,7 @@ extension ImagePickerController: ImageGalleryPanGestureDelegate {
 
   func panGestureDidEnd(_ translation: CGPoint, velocity: CGPoint) {
     guard let initialFrame = initialFrame else { return }
-
     let galleryHeight = initialFrame.height - translation.y
-
     if galleryView.frame.height < GestureConstants.minimumHeight && velocity.y < 0 {
       showGalleryView()
     } else if velocity.y < -GestureConstants.velocity {


### PR DESCRIPTION
clean up SwiftLint warnings
1. extra space before ':'
2. extra space before ','
3. file size exceed 200 lines
