### PR TITLE
Correct version of Sugar

### DIFF
--- a/Demo/ImagePickerDemo/Podfile
+++ b/Demo/ImagePickerDemo/Podfile
@@ -6,6 +6,6 @@ inhibit_all_warnings!
 target 'ImagePickerDemo' do
 	pod 'ImagePicker', path: '../../'
 	pod 'Lightbox', git: 'https://github.com/hyperoslo/Lightbox.git', branch: 'swift-3'
-	pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar.git', branch: 'swift-3'
+	pod 'Sugar', git: 'https://github.com/hyperoslo/Sugar.git', branch: 'master'
 	pod 'Hue', git: 'https://github.com/hyperoslo/Hue.git', branch: 'swift3'
 end


### PR DESCRIPTION
I do not see any `swift-3` branch in `Sugar` repo. `ImagePicker` was installing version `1.2.0` of `Sugar` which was giving compile time error for `Localization.swift` file.  Using latest version of `Sugar` in `ImagePickerDemo` in which that error has been fixed. 

Thoughts?