### PR TITLE
limit users to selecting only one photo

### DIFF
--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -42,6 +42,7 @@ public struct Configuration {
   public static var canRotateCamera = true
   public static var collapseCollectionViewWhileShot = true
   public static var recordLocation = true
+  public static var allowMultiplePhotoSelection = true
 
   // MARK: Images
   public static var indicatorView: UIView = {

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -201,6 +201,23 @@ extension ImageGalleryView: UICollectionViewDelegate {
   public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     guard let cell = collectionView.cellForItem(at: indexPath)
       as? ImageGalleryViewCell else { return }
+    if Configuration.allowMultiplePhotoSelection == false {
+      // Clear selected photos array
+      for asset in self.selectedStack.assets {
+        self.selectedStack.dropAsset(asset)
+      }
+      // Animate deselecting photos for any selected visible cells
+      guard let visibleCells = collectionView.visibleCells as? [ImageGalleryViewCell] else { return }
+      for cell in visibleCells {
+        if cell.selectedImageView.image != nil {
+          UIView.animate(withDuration: 0.2, animations: {
+            cell.selectedImageView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+          }, completion: { _ in
+            cell.selectedImageView.image = nil
+          })
+        }
+      }
+    }
 
     let asset = assets[(indexPath as NSIndexPath).row]
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -371,8 +371,12 @@ extension ImagePickerController: CameraViewDelegate {
 
     galleryView.fetchPhotos() {
       guard let asset = self.galleryView.assets.first else { return }
+      if Configuration.allowMultiplePhotoSelection == false {
+        self.stack.assets.removeAll()
+      }
       self.stack.pushAsset(asset)
     }
+    
     galleryView.shouldTransform = true
     bottomContainer.pickerButton.isEnabled = true
 


### PR DESCRIPTION
Add custom property to Configuration that limits photo selection to one. Simply animate deselection of visible cells in 'didSelectItem', and remove selected photos from photo stack array.