### PR TITLE
Fix loading

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -18,17 +18,19 @@ open class AssetManager {
   open static func fetch(_ completion: @escaping (_ assets: [PHAsset]) -> Void) {
     guard PHPhotoLibrary.authorizationStatus() == .authorized else { return }
 
-    let fetchResult = PHAsset.fetchAssets(with: .image, options: PHFetchOptions())
+    DispatchQueue.global(qos: .background).async {
+      let fetchResult = PHAsset.fetchAssets(with: .image, options: PHFetchOptions())
 
-    if fetchResult.count > 0 {
-      var assets = [PHAsset]()
-      fetchResult.enumerateObjects({ object, index, stop in
-        assets.insert(object, at: 0)
-      })
+      if fetchResult.count > 0 {
+        var assets = [PHAsset]()
+        fetchResult.enumerateObjects({ object, index, stop in
+          assets.insert(object, at: 0)
+        })
 
-      DispatchQueue.main.async(execute: {
-        completion(assets)
-      })
+        DispatchQueue.main.async {
+          completion(assets)
+        }
+      }
     }
   }
 

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -1,25 +1,7 @@
 import Foundation
 import UIKit
 import Photos
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l < r
-  case (nil, _?):
-    return true
-  default:
-    return false
-  }
-}
 
-fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l > r
-  default:
-    return rhs < lhs
-  }
-}
 open class AssetManager {
 
   open static func getImage(_ name: String) -> UIImage {
@@ -34,19 +16,13 @@ open class AssetManager {
   }
 
   open static func fetch(_ completion: @escaping (_ assets: [PHAsset]) -> Void) {
-    let fetchOptions = PHFetchOptions()
-    let authorizationStatus = PHPhotoLibrary.authorizationStatus()
-    var fetchResult: PHFetchResult<PHAsset>?
+    guard PHPhotoLibrary.authorizationStatus() == .authorized else { return }
 
-    guard authorizationStatus == .authorized else { return }
+    let fetchResult = PHAsset.fetchAssets(with: .image, options: PHFetchOptions())
 
-    if fetchResult == nil {
-      fetchResult = PHAsset.fetchAssets(with: .image, options: fetchOptions)
-    }
-
-    if fetchResult?.count > 0 {
+    if fetchResult.count > 0 {
       var assets = [PHAsset]()
-      fetchResult?.enumerateObjects({ object, index, stop in
+      fetchResult.enumerateObjects({ object, index, stop in
         assets.insert(object, at: 0)
       })
 

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -84,7 +84,6 @@ open class ImageGalleryView: UIView {
   var shouldTransform = false
   var imagesBeforeLoading = 0
   var fetchResult: PHFetchResult<AnyObject>?
-  var canFetchImages = false
   var imageLimit = 0
 
   // MARK: - Initializers
@@ -240,15 +239,5 @@ extension ImageGalleryView: UICollectionViewDelegate {
         self.selectedStack.pushAsset(asset)
       }
     }
-  }
-
-  public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell,
-    forItemAt indexPath: IndexPath) {
-      guard (indexPath as NSIndexPath).row + 10 >= assets.count
-        && (indexPath as NSIndexPath).row < fetchResult?.count
-        && canFetchImages else { return }
-
-      fetchPhotos()
-      canFetchImages = false
   }
 }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -189,7 +189,6 @@ open class ImagePickerController: UIViewController {
 
   func permissionGranted() {
     galleryView.fetchPhotos()
-    galleryView.canFetchImages = false
     enableGestures(true)
   }
 


### PR DESCRIPTION
- Remove unneeded generated custom operators
- Move fetching asset into background queue, hopefully will relieve this https://github.com/hyperoslo/ImagePicker/issues/243. This helps a bit, as although the `fetch` method is sync, but PhotoKit is designed to perform lazy loading, and in batch