### PR TITLE
Use system fonts instead of predefined strings

### DIFF
--- a/Demo/ImagePickerDemo/Podfile
+++ b/Demo/ImagePickerDemo/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '8.0'
+platform :ios, '8.2'
 
 use_frameworks!
 inhibit_all_warnings!

--- a/Demo/ImagePickerDemo/Podfile.lock
+++ b/Demo/ImagePickerDemo/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - Lightbox (1.0.0):
     - Hue
     - Sugar
-  - Sugar (3.0.0)
+  - Sugar (3.1.2)
 
 DEPENDENCIES:
   - Hue (from `https://github.com/hyperoslo/Hue.git`, branch `swift3`)
@@ -33,15 +33,15 @@ CHECKOUT OPTIONS:
     :commit: 04437d8450a5ccc92af7e9bd08027bdced9fb589
     :git: https://github.com/hyperoslo/Lightbox.git
   Sugar:
-    :commit: 08349d9b9b6d34bba0370be323fb096ee27ea129
+    :commit: 9ab7edb15a436310ca38083cf5e25e7251541ddc
     :git: https://github.com/hyperoslo/Sugar.git
 
 SPEC CHECKSUMS:
   Hue: 0705083b7aff40334033373e6293ec1215285ac2
-  ImagePicker: 81175d36c2852cb543cb4f5d6c19e28f3e8d90eb
+  ImagePicker: 036ad79e41064dea59e1b0f9b913174a17656089
   Lightbox: e4523e8cf3261cbc833d0e76ae4dae774731d115
-  Sugar: 013db92ee417299586c93007ca2d91f09a29dae3
+  Sugar: 41f2efa0244806f524ff2d77c951a6a43e81a0f3
 
-PODFILE CHECKSUM: 47a31d1243de4e3ad14973e03ed0bba90dca43cc
+PODFILE CHECKSUM: aabd6946b20683e97c4940a3ab1e5aad181462fd
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0

--- a/ImagePicker.podspec
+++ b/ImagePicker.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }
   s.source           = { :git => "https://github.com/hyperoslo/ImagePicker.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/hyperoslo'
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '8.2'
   s.requires_arc = true
   s.source_files = 'Source/**/*'
   s.resource_bundles = { 'ImagePicker' => ['Images/*.{png}'] }

--- a/ImagePicker.xcodeproj/project.pbxproj
+++ b/ImagePicker.xcodeproj/project.pbxproj
@@ -483,7 +483,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/SupportFiles/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ImagePicker;
 				PRODUCT_NAME = ImagePicker;
@@ -503,7 +503,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/SupportFiles/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ImagePicker;
 				PRODUCT_NAME = ImagePicker;

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -14,12 +14,12 @@ public struct Configuration {
 
   // MARK: Fonts
 
-  public var numberLabelFont = UIFont(name: "HelveticaNeue-Bold", size: 19)!
-  public var doneButton = UIFont(name: "HelveticaNeue-Medium", size: 19)!
-  public var flashButton = UIFont(name: "HelveticaNeue-Medium", size: 12)!
-  public var noImagesFont = UIFont(name: "HelveticaNeue-Medium", size: 18)!
-  public var noCameraFont = UIFont(name: "HelveticaNeue-Medium", size: 18)!
-  public var settingsFont = UIFont(name: "HelveticaNeue-Medium", size: 16)!
+  public var numberLabelFont = UIFont.systemFont(ofSize: 19, weight: UIFontWeightBold)
+  public var doneButton = UIFont.systemFont(ofSize: 19, weight: UIFontWeightMedium)
+  public var flashButton = UIFont.systemFont(ofSize: 12, weight: UIFontWeightMedium)
+  public var noImagesFont = UIFont.systemFont(ofSize: 18, weight: UIFontWeightMedium)
+  public var noCameraFont = UIFont.systemFont(ofSize: 18, weight: UIFontWeightMedium)
+  public var settingsFont = UIFont.systemFont(ofSize: 16, weight: UIFontWeightMedium)
 
   // MARK: Titles
 


### PR DESCRIPTION
Fix for #256 
This PR increases minimum deployment target of the app which uses this library to 8.2 (from 8), but I think, it's OK now when almost everybody is on iOS 10+.