### PR TITLE
Update example with configuration in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ configuration.doneButtonTitle = "Finish"
 configuration.noImagesTitle = "Sorry! There are no images here!"
 configuration.recordLocation = false
 
-let imagePicker = ImagePickerController()
-imagePicker.configuration = configuration
+let imagePicker = ImagePickerController(configuration: configuration)
 ```
 
 ##### Resolve assets


### PR DESCRIPTION
Currently, the reader may get an impression that `Configuration` can be changed dynamically, after `ImagePickerController` has been initialized. However, it does not support this feature, so I've changed example to reflect this case better.
I use `configuration` as a parameter to initialize `ImagePickerController`, so that it is clear, it cannot be mutated after initialization.