### PR TITLE
Add configuration setting to hide number count label

### DIFF
--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -20,6 +20,7 @@ open class BottomContainerView: UIView {
     let pickerButton = ButtonPicker()
     pickerButton.setTitleColor(UIColor.white, for: UIControlState())
     pickerButton.delegate = self
+    pickerButton.numberLabel.isHidden = !self.configuration.showsImageCountLabel
 
     return pickerButton
     }()

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -45,6 +45,7 @@ public struct Configuration {
   public var recordLocation = true
   public var allowMultiplePhotoSelection = true
   public var allowVideoSelection = false
+  public var showsImageCountLabel = true
 
   // MARK: Images
   public var indicatorView: UIView = {


### PR DESCRIPTION
In my use case, when using an imageLimit of 1 item, it didn't really make sense to show the number of selected images.

Feel free to close if you don't think this configuration is useful.