### PR TITLE
ButtonPicker title font configuration bug fix

### DIFF
--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -17,7 +17,7 @@ open class BottomContainerView: UIView {
   var configuration = Configuration()
 
   lazy var pickerButton: ButtonPicker = { [unowned self] in
-    let pickerButton = ButtonPicker()
+    let pickerButton = ButtonPicker(configuration: self.configuration)
     pickerButton.setTitleColor(UIColor.white, for: UIControlState())
     pickerButton.delegate = self
     pickerButton.numberLabel.isHidden = !self.configuration.showsImageCountLabel


### PR DESCRIPTION
Configuration field numberLabelFont had no effect because ButtonPicker was not initialising with configuration. This fixes the problem.