### PR TITLE
Add option to set flash button to be always hidden

### DIFF
--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -271,7 +271,9 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
   }
 
   func cameraMan(_ cameraMan: CameraMan, didChangeInput input: AVCaptureDeviceInput) {
-    delegate?.setFlashButtonHidden(!input.device.hasFlash)
+    if !configuration.flashButtonAlwaysHidden {
+      delegate?.setFlashButtonHidden(!input.device.hasFlash)
+    }
   }
 
   func cameraManDidStart(_ cameraMan: CameraMan) {

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -46,6 +46,7 @@ public struct Configuration {
   public var allowMultiplePhotoSelection = true
   public var allowVideoSelection = false
   public var showsImageCountLabel = true
+  public var flashButtonAlwaysHidden = false
 
   // MARK: Images
   public var indicatorView: UIView = {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -381,7 +381,9 @@ extension ImagePickerController: BottomContainerViewDelegate {
 extension ImagePickerController: CameraViewDelegate {
 
   func setFlashButtonHidden(_ hidden: Bool) {
-    topView.flashButton.isHidden = hidden
+    if configuration.flashButtonAlwaysHidden {
+      topView.flashButton.isHidden = hidden
+    }
   }
 
   func imageToLibrary() {

--- a/Source/TopView/TopView.swift
+++ b/Source/TopView/TopView.swift
@@ -79,6 +79,8 @@ class TopView: UIView {
       addSubview(button)
     }
 
+    flashButton.isHidden = configuration.flashButtonAlwaysHidden
+
     setupConstraints()
   }
 


### PR DESCRIPTION
Fix issue #303, cc @kohdesmond

I've added entry in configuration allowing setting flash button to be always hidden, independent of device type or state.