### PR TITLE
Fix constraint setup when presented in landscape orientation 

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -22,7 +22,7 @@ open class AssetManager {
       let fetchResult = configuration.allowVideoSelection
         ? PHAsset.fetchAssets(with: PHFetchOptions())
         : PHAsset.fetchAssets(with: .image, options: PHFetchOptions())
-        
+
       if fetchResult.count > 0 {
         var assets = [PHAsset]()
         fetchResult.enumerateObjects({ object, index, stop in

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -25,7 +25,7 @@ open class AssetManager {
 
       if fetchResult.count > 0 {
         var assets = [PHAsset]()
-        fetchResult.enumerateObjects({ object, index, stop in
+        fetchResult.enumerateObjects({ object, _, _ in
           assets.insert(object, at: 0)
         })
 
@@ -58,7 +58,7 @@ open class AssetManager {
 
     var images = [UIImage]()
     for asset in assets {
-      imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: requestOptions) { image, info in
+      imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: requestOptions) { image, _ in
         if let image = image {
           images.append(image)
         }

--- a/Source/BottomView/ImageStack.swift
+++ b/Source/BottomView/ImageStack.swift
@@ -18,7 +18,7 @@ open class ImageStack {
   }
 
   open func dropAsset(_ asset: PHAsset) {
-    assets = assets.filter() {$0 != asset}
+    assets = assets.filter {$0 != asset}
     NotificationCenter.default.post(name: Notification.Name(rawValue: Notifications.imageDidDrop), object: self, userInfo: [imageKey: asset])
   }
 

--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -156,9 +156,7 @@ class CameraMan {
     connection.videoOrientation = Helper.videoOrientation()
 
     queue.async {
-      self.stillImageOutput?.captureStillImageAsynchronously(from: connection) {
-        buffer, error in
-
+      self.stillImageOutput?.captureStillImageAsynchronously(from: connection) { buffer, error in
         guard let buffer = buffer, error == nil && CMSampleBufferIsValid(buffer),
           let imageData = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer),
           let image = UIImage(data: imageData)

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -89,14 +89,13 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
   var locationManager: LocationManager?
   var startOnFrontCamera: Bool = false
 
-
   public init(configuration: Configuration? = nil) {
     if let configuration = configuration {
       self.configuration = configuration
     }
     super.init(nibName: nil, bundle: nil)
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -59,8 +59,8 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     let button = UIButton(type: .system)
     let title = NSAttributedString(string: self.configuration.settingsTitle,
       attributes: [
-        NSFontAttributeName : self.configuration.settingsFont,
-        NSForegroundColorAttributeName : self.configuration.settingsColor,
+        NSFontAttributeName: self.configuration.settingsFont,
+        NSForegroundColorAttributeName: self.configuration.settingsColor
       ])
 
     button.setAttributedTitle(title, for: UIControlState())
@@ -199,7 +199,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     cameraMan.flash(mapping[title] ?? .auto)
   }
 
-  func takePicture(_ completion: @escaping () -> ()) {
+  func takePicture(_ completion: @escaping () -> Void) {
     guard let previewLayer = previewLayer else { return }
 
     UIView.animate(withDuration: 0.1, animations: {

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -49,7 +49,6 @@ public struct Configuration {
   public var flashButtonAlwaysHidden = false
   public var managesAudioSession = true
 
-
   // MARK: Images
   public var indicatorView: UIView = {
     let view = UIView()

--- a/Source/Extensions/ConstraintsSetup.swift
+++ b/Source/Extensions/ConstraintsSetup.swift
@@ -44,13 +44,15 @@ extension BottomContainerView {
       relatedBy: .equal, toItem: self, attribute: .centerY,
       multiplier: 1, constant: -2))
 
+    let screenSize = Helper.screenSizeForOrientation()
+
     addConstraint(NSLayoutConstraint(item: doneButton, attribute: .centerX,
       relatedBy: .equal, toItem: self, attribute: .right,
-      multiplier: 1, constant: -(UIScreen.main.bounds.width - (ButtonPicker.Dimensions.buttonBorderSize + UIScreen.main.bounds.width)/2)/2))
+      multiplier: 1, constant: -(screenSize.width - (ButtonPicker.Dimensions.buttonBorderSize + screenSize.width)/2)/2))
 
     addConstraint(NSLayoutConstraint(item: stackView, attribute: .centerX,
       relatedBy: .equal, toItem: self, attribute: .left,
-      multiplier: 1, constant: UIScreen.main.bounds.width/4 - ButtonPicker.Dimensions.buttonBorderSize/3))
+      multiplier: 1, constant: screenSize.width/4 - ButtonPicker.Dimensions.buttonBorderSize/3))
 
     addConstraint(NSLayoutConstraint(item: topSeparator, attribute: .height,
       relatedBy: .equal, toItem: nil, attribute: .notAnAttribute,

--- a/Source/Helper.swift
+++ b/Source/Helper.swift
@@ -25,4 +25,14 @@ struct Helper {
     default: return .portrait
     }
   }
+
+  static func screenSizeForOrientation() -> CGSize {
+    switch UIDevice.current.orientation {
+    case .landscapeLeft, .landscapeRight:
+      return CGSize(width: UIScreen.main.bounds.height,
+                    height: UIScreen.main.bounds.width)
+    default:
+      return UIScreen.main.bounds.size
+    }
+  }
 }

--- a/Source/ImageGallery/ImageGalleryLayout.swift
+++ b/Source/ImageGallery/ImageGalleryLayout.swift
@@ -6,14 +6,14 @@ class ImageGalleryLayout: UICollectionViewFlowLayout {
     guard let attributes = super.layoutAttributesForElements(in: rect) else {
       return super.layoutAttributesForElements(in: rect)
     }
-    
+
     var newAttributes = [UICollectionViewLayoutAttributes]()
     for attribute in attributes {
       let n = attribute.copy() as! UICollectionViewLayoutAttributes
       n.transform = Helper.rotationTransform()
       newAttributes.append(n)
     }
-    
+
     return newAttributes
   }
 }

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -11,7 +11,6 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   }
 }
 
-
 protocol ImageGalleryPanGestureDelegate: class {
 
   func panGestureDidStart()

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Photos
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
+private func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
     return l < r
@@ -197,8 +197,8 @@ open class ImageGalleryView: UIView {
 extension ImageGalleryView: UICollectionViewDelegateFlowLayout {
 
   public func collectionView(_ collectionView: UICollectionView,
-    layout collectionViewLayout: UICollectionViewLayout,
-    sizeForItemAt indexPath: IndexPath) -> CGSize {
+                             layout collectionViewLayout: UICollectionViewLayout,
+                             sizeForItemAt indexPath: IndexPath) -> CGSize {
       guard let collectionSize = collectionSize else { return CGSize.zero }
 
       return collectionSize
@@ -219,21 +219,19 @@ extension ImageGalleryView: UICollectionViewDelegate {
       }
       // Animate deselecting photos for any selected visible cells
       guard let visibleCells = collectionView.visibleCells as? [ImageGalleryViewCell] else { return }
-      for cell in visibleCells {
-        if cell.selectedImageView.image != nil {
-          UIView.animate(withDuration: 0.2, animations: {
-            cell.selectedImageView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
-          }, completion: { _ in
-            cell.selectedImageView.image = nil
-          })
-        }
+      for cell in visibleCells where cell.selectedImageView.image != nil {
+        UIView.animate(withDuration: 0.2, animations: {
+          cell.selectedImageView.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+        }, completion: { _ in
+          cell.selectedImageView.image = nil
+        })
       }
     }
 
     let asset = assets[(indexPath as NSIndexPath).row]
 
     AssetManager.resolveAsset(asset, size: CGSize(width: 100, height: 100)) { image in
-      guard let _ = image else { return }
+      guard image != nil else { return }
 
       if cell.selectedImageView.image != nil {
         UIView.animate(withDuration: 0.2, animations: {

--- a/Source/ImageGallery/ImageGalleryViewCell.swift
+++ b/Source/ImageGallery/ImageGalleryViewCell.swift
@@ -5,7 +5,7 @@ class ImageGalleryViewCell: UICollectionViewCell {
   lazy var imageView = UIImageView()
   lazy var selectedImageView = UIImageView()
   private var videoInfoView: VideoInfoView
-  
+
   private let videoInfoBarHeight: CGFloat = 15
   var duration: TimeInterval? {
     didSet {
@@ -17,7 +17,7 @@ class ImageGalleryViewCell: UICollectionViewCell {
       }
     }
   }
-  
+
   override init(frame: CGRect) {
     let videoBarFrame = CGRect(x: 0, y: frame.height - self.videoInfoBarHeight,
                                width: frame.width, height: self.videoInfoBarHeight)

--- a/Source/ImageGallery/VideoInfoView.swift
+++ b/Source/ImageGallery/VideoInfoView.swift
@@ -17,7 +17,7 @@ class VideoInfoView: UIView {
     videoIcon.contentMode = .scaleAspectFit
     return videoIcon
   }()
-    
+
   private lazy var videoInfoLabel: UILabel = {
     let videoInfoLabel = UILabel(frame: CGRect(x: 0,
                                                y: 0,
@@ -29,7 +29,7 @@ class VideoInfoView: UIView {
     videoInfoLabel.text = self.dateFormatter.string(from: self.duration ?? 0)
     return videoInfoLabel
   }()
-    
+
   private lazy var dateFormatter: DateComponentsFormatter = {
     let formatter = DateComponentsFormatter()
     formatter.zeroFormattingBehavior = .pad

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -157,6 +157,8 @@ open class ImagePickerController: UIViewController {
 
     initialFrame = galleryView.frame
     initialContentOffset = galleryView.collectionView.contentOffset
+
+    applyOrientationTransforms()
   }
 
   open override func viewWillDisappear(_ animated: Bool) {
@@ -425,11 +427,15 @@ extension ImagePickerController: CameraViewDelegate {
   }
 
   public func handleRotation(_ note: Notification) {
+    applyOrientationTransforms()
+  }
+
+  func applyOrientationTransforms() {
     let rotate = Helper.rotationTransform()
 
     UIView.animate(withDuration: 0.25, animations: {
       [self.topView.rotateCamera, self.bottomContainer.pickerButton,
-        self.bottomContainer.stackView, self.bottomContainer.doneButton].forEach {
+       self.bottomContainer.stackView, self.bottomContainer.doneButton].forEach {
         $0.transform = rotate
       }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -97,11 +97,11 @@ open class ImagePickerController: UIViewController {
     }
     super.init(nibName: nil, bundle: nil)
   }
-  
+
   public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }
-  
+
   required public init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
   }
@@ -401,7 +401,7 @@ extension ImagePickerController: CameraViewDelegate {
       }
       self.stack.pushAsset(asset)
     }
-    
+
     galleryView.shouldTransform = true
     bottomContainer.pickerButton.isEnabled = true
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -335,7 +335,7 @@ open class ImagePickerController: UIViewController {
     isTakingPicture = true
     bottomContainer.pickerButton.isEnabled = false
     bottomContainer.stackView.startLoader()
-    let action: (Void) -> Void = { [unowned self] in
+    let action: () -> Void = { [unowned self] in
       self.cameraController.takePicture { self.isTakingPicture = false }
     }
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -394,7 +394,7 @@ extension ImagePickerController: CameraViewDelegate {
   func imageToLibrary() {
     guard let collectionSize = galleryView.collectionSize else { return }
 
-    galleryView.fetchPhotos() {
+    galleryView.fetchPhotos {
       guard let asset = self.galleryView.assets.first else { return }
       if self.configuration.allowMultiplePhotoSelection == false {
         self.stack.assets.removeAll()


### PR DESCRIPTION
When the ImagePicker is presented in `landscapeLeft` or `landscapeRight` orientation the constraints applied to the subviews of `BottomContainerView` are broken.

![simulator screen shot 8 aug 2017 10 45 18](https://user-images.githubusercontent.com/3531480/29066287-b2ca8d28-7c26-11e7-9c06-54e0fd2b5754.png)

I have added a helper function to return the `CGSize` of the screen in the current orientation which enables the correct constraint calculation. I have also applied the rotation transforms when the view appears on screen which is consistent with the native iOS camera.

There are some code tidy ups which consist mostly of whitespace removal, trailing closure syntax and parameter alignment. I hope these are in keeping with the style guide but I'm happy to remove them if they violate any guide rules.
