### PR TITLE
No Images Available animation glitch

### DIFF
--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -137,6 +137,7 @@ open class ImageGalleryView: UIView {
       width: configuration.indicatorWidth, height: configuration.indicatorHeight)
     collectionView.frame = CGRect(x: 0, y: topSeparator.frame.height, width: totalWidth, height: collectionFrame - topSeparator.frame.height)
     collectionSize = CGSize(width: collectionView.frame.height, height: collectionView.frame.height)
+    noImagesLabel.center = CGPoint(x: bounds.width / 2, y: (bounds.height + Dimensions.galleryBarHeight) / 2)
 
     collectionView.reloadData()
   }
@@ -149,7 +150,7 @@ open class ImageGalleryView: UIView {
       if threshold > height || self.collectionView.alpha != 0 {
         self.noImagesLabel.alpha = 0
       } else {
-        self.noImagesLabel.center = CGPoint(x: self.bounds.width / 2, y: height / 2)
+        self.noImagesLabel.center = CGPoint(x: self.bounds.width / 2, y: (height + Dimensions.galleryBarHeight) / 2)
         self.noImagesLabel.alpha = (height > threshold) ? 1 : (height - Dimensions.galleryBarHeight) / threshold
       }
     })


### PR DESCRIPTION
This should fix - https://github.com/hyperoslo/ImagePicker/issues/258

Setting the `noImagesLabel` frame when also setting up the collection view frame solves the label animating in from the top left of the view. I also added the height of the gallery bar to fully center the label in the view.

**Before**
![before](https://user-images.githubusercontent.com/3531480/29227081-53a81218-7ecc-11e7-902f-ea29089a93d0.gif)

**After**
![after](https://user-images.githubusercontent.com/3531480/29227082-5552e1f6-7ecc-11e7-96ac-49d34b076039.gif)
