### PR TITLE
Add pinch to zoom

### DIFF
--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -204,6 +204,16 @@ class CameraMan {
     }
   }
 
+  func zoom(_ zoomFactor: CGFloat) {
+    guard let device = currentInput?.device, device.position == .back else { return }
+
+    queue.async {
+      self.lock {
+        device.videoZoomFactor = zoomFactor
+      }
+    }
+  }
+
   // MARK: - Lock
 
   func lock(_ block: () -> Void) {

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -81,6 +81,13 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     return gesture
     }()
 
+  lazy var pinchGestureRecognizer: UIPinchGestureRecognizer = { [unowned self] in
+    let gesture = UIPinchGestureRecognizer()
+    gesture.addTarget(self, action: #selector(pinchGestureRecognizerHandler(_:)))
+
+    return gesture
+    }()
+
   let cameraMan = CameraMan()
 
   var previewLayer: AVCaptureVideoPreviewLayer?
@@ -88,6 +95,12 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
   var animationTimer: Timer?
   var locationManager: LocationManager?
   var startOnFrontCamera: Bool = false
+
+  private let minimumZoomFactor: CGFloat = 1.0
+  private let maximumZoomFactor: CGFloat = 3.0
+
+  private var currentZoomFactor: CGFloat = 1.0
+  private var previousZoomFactor: CGFloat = 1.0
 
   public init(configuration: Configuration? = nil) {
     if let configuration = configuration {
@@ -117,6 +130,10 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     }
 
     view.addGestureRecognizer(tapGestureRecognizer)
+
+    if configuration.allowPinchToZoom {
+      view.addGestureRecognizer(pinchGestureRecognizer)
+    }
 
     cameraMan.delegate = self
     cameraMan.setup(self.startOnFrontCamera)
@@ -244,6 +261,16 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     })
   }
 
+  func zoomTo(_ zoomFactor: CGFloat) {
+    guard let device = cameraMan.currentInput?.device else { return }
+
+    let maximumDeviceZoomFactor = device.activeFormat.videoMaxZoomFactor
+    let newZoomFactor = previousZoomFactor * zoomFactor
+    currentZoomFactor = min(maximumZoomFactor, max(minimumZoomFactor, min(newZoomFactor, maximumDeviceZoomFactor)))
+
+    cameraMan.zoom(currentZoomFactor)
+  }
+
   // MARK: - Tap
 
   func tapGestureRecognizerHandler(_ gesture: UITapGestureRecognizer) {
@@ -252,6 +279,21 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     focusImageView.transform = CGAffineTransform.identity
     animationTimer?.invalidate()
     focusTo(touch)
+  }
+
+  // MARK: - Pinch
+
+  func pinchGestureRecognizerHandler(_ gesture: UIPinchGestureRecognizer) {
+    switch gesture.state {
+    case .began:
+      fallthrough
+    case .changed:
+      zoomTo(gesture.scale)
+    case .ended:
+      zoomTo(gesture.scale)
+      previousZoomFactor = currentZoomFactor
+    default: break
+    }
   }
 
   // MARK: - Private helpers

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -48,6 +48,7 @@ public struct Configuration {
   public var showsImageCountLabel = true
   public var flashButtonAlwaysHidden = false
   public var managesAudioSession = true
+  public var allowPinchToZoom = true
 
   // MARK: Images
   public var indicatorView: UIView = {


### PR DESCRIPTION
This is an initial implementation of pinch to zoom. I noticed it was a requested feature in the [issues](https://github.com/hyperoslo/ImagePicker/issues/308) and thought I would give it a try.

I have limited the maximum zoom to a factor of `3.0` which feels consistent with the standard iOS camera however we could change that and have it to go to `videoMaxZoomFactor` if we wanted. It might be nice to combine this with a pan gesture and slider like the standard iOS camera.

I have added `allowPinchToZoom` to the `Configuration` and set the default value to `true` but it might be better to have this off by default?