### PR TITLE
Fix rendering of **bold** text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ## Description
 
 <img src="https://github.com/hyperoslo/ImagePicker/blob/master/Resources/ImagePickerIcon.png" alt="ImagePicker Icon" align="right" />
+
 **ImagePicker** is an all-in-one camera solution for your iOS app. It lets your users select images from the library and take pictures at the same time. As a developer you get notified of all the user interactions and get the beautiful UI for free, out of the box, it's just that simple.
 
 **ImagePicker** has been optimized to give a great user experience, it passes around referenced images instead of the image itself which makes it less memory consuming. This is what makes it smooth as butter.


### PR DESCRIPTION
This pull request fixes incorrect markdown rendering.
An extra `newline` character is needed after a html code, or the text attributes are not rendered correctly, as shown on screenshots.
**Before:**
<img width="177" alt="screen shot 2017-10-01 at 05 40 15" src="https://user-images.githubusercontent.com/8013017/31051232-8639d97a-a66b-11e7-8275-ae5de6e01086.png">
**After:**
<img width="184" alt="screen shot 2017-10-01 at 05 41 16" src="https://user-images.githubusercontent.com/8013017/31051233-8dd2861e-a66b-11e7-98e0-01342a801e53.png">
