### PR TITLE
Add support for Objective-C, remove deprecations

### DIFF
--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -1,59 +1,59 @@
 import AVFoundation
 import UIKit
 
-public struct Configuration {
+@objc public class Configuration: NSObject {
 
   // MARK: Colors
 
-  public var backgroundColor = UIColor(red: 0.15, green: 0.19, blue: 0.24, alpha: 1)
-  public var gallerySeparatorColor = UIColor.black.withAlphaComponent(0.6)
-  public var mainColor = UIColor(red: 0.09, green: 0.11, blue: 0.13, alpha: 1)
-  public var noImagesColor = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1)
-  public var noCameraColor = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1)
-  public var settingsColor = UIColor.white
-  public var bottomContainerColor = UIColor(red: 0.09, green: 0.11, blue: 0.13, alpha: 1)
+  @objc public var backgroundColor = UIColor(red: 0.15, green: 0.19, blue: 0.24, alpha: 1)
+  @objc public var gallerySeparatorColor = UIColor.black.withAlphaComponent(0.6)
+  @objc public var mainColor = UIColor(red: 0.09, green: 0.11, blue: 0.13, alpha: 1)
+  @objc public var noImagesColor = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1)
+  @objc public var noCameraColor = UIColor(red: 0.86, green: 0.86, blue: 0.86, alpha: 1)
+  @objc public var settingsColor = UIColor.white
+  @objc public var bottomContainerColor = UIColor(red: 0.09, green: 0.11, blue: 0.13, alpha: 1)
 
   // MARK: Fonts
 
-  public var numberLabelFont = UIFont.systemFont(ofSize: 19, weight: UIFont.Weight.bold)
-  public var doneButton = UIFont.systemFont(ofSize: 19, weight: UIFont.Weight.medium)
-  public var flashButton = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.medium)
-  public var noImagesFont = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.medium)
-  public var noCameraFont = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.medium)
-  public var settingsFont = UIFont.systemFont(ofSize: 16, weight: UIFont.Weight.medium)
+  @objc public var numberLabelFont = UIFont.systemFont(ofSize: 19, weight: UIFont.Weight.bold)
+  @objc public var doneButton = UIFont.systemFont(ofSize: 19, weight: UIFont.Weight.medium)
+  @objc public var flashButton = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.medium)
+  @objc public var noImagesFont = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.medium)
+  @objc public var noCameraFont = UIFont.systemFont(ofSize: 18, weight: UIFont.Weight.medium)
+  @objc public var settingsFont = UIFont.systemFont(ofSize: 16, weight: UIFont.Weight.medium)
 
   // MARK: Titles
 
-  public var OKButtonTitle = "OK"
-  public var cancelButtonTitle = "Cancel"
-  public var doneButtonTitle = "Done"
-  public var noImagesTitle = "No images available"
-  public var noCameraTitle = "Camera is not available"
-  public var settingsTitle = "Settings"
-  public var requestPermissionTitle = "Permission denied"
-  public var requestPermissionMessage = "Please, allow the application to access to your photo library."
+  @objc public var OKButtonTitle = "OK"
+  @objc public var cancelButtonTitle = "Cancel"
+  @objc public var doneButtonTitle = "Done"
+  @objc public var noImagesTitle = "No images available"
+  @objc public var noCameraTitle = "Camera is not available"
+  @objc public var settingsTitle = "Settings"
+  @objc public var requestPermissionTitle = "Permission denied"
+  @objc public var requestPermissionMessage = "Please, allow the application to access to your photo library."
 
   // MARK: Dimensions
 
-  public var cellSpacing: CGFloat = 2
-  public var indicatorWidth: CGFloat = 41
-  public var indicatorHeight: CGFloat = 8
+  @objc public var cellSpacing: CGFloat = 2
+  @objc public var indicatorWidth: CGFloat = 41
+  @objc public var indicatorHeight: CGFloat = 8
 
   // MARK: Custom behaviour
 
-  public var canRotateCamera = true
-  public var collapseCollectionViewWhileShot = true
-  public var recordLocation = true
-  public var allowMultiplePhotoSelection = true
-  public var allowVideoSelection = false
-  public var showsImageCountLabel = true
-  public var flashButtonAlwaysHidden = false
-  public var managesAudioSession = true
-  public var allowPinchToZoom = true
-  public var allowedOrientations = UIInterfaceOrientationMask.all
+  @objc public var canRotateCamera = true
+  @objc public var collapseCollectionViewWhileShot = true
+  @objc public var recordLocation = true
+  @objc public var allowMultiplePhotoSelection = true
+  @objc public var allowVideoSelection = false
+  @objc public var showsImageCountLabel = true
+  @objc public var flashButtonAlwaysHidden = false
+  @objc public var managesAudioSession = true
+  @objc public var allowPinchToZoom = true
+  @objc public var allowedOrientations = UIInterfaceOrientationMask.all
 
   // MARK: Images
-  public var indicatorView: UIView = {
+  @objc public var indicatorView: UIView = {
     let view = UIView()
     view.backgroundColor = UIColor.white.withAlphaComponent(0.6)
     view.layer.cornerRadius = 4
@@ -61,13 +61,13 @@ public struct Configuration {
     return view
   }()
 
-  public init() {}
+  override public init() {}
 }
 
 // MARK: - Orientation
 extension Configuration {
 
-  public var rotationTransform: CGAffineTransform {
+  @objc public var rotationTransform: CGAffineTransform {
     let currentOrientation = UIDevice.current.orientation
 
     // check if current orientation is allowed
@@ -105,6 +105,5 @@ extension Configuration {
     }
 
     return Helper.getTransform(fromDeviceOrientation: Helper.previousOrientation)
-}
-
+  }
 }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -136,7 +136,6 @@ open class ImagePickerController: UIViewController {
     }
 
     statusBarHidden = UIApplication.shared.isStatusBarHidden
-    UIApplication.shared.setStatusBarHidden(true, with: .fade)
 
     self.handleRotation(nil)
   }
@@ -161,11 +160,6 @@ open class ImagePickerController: UIViewController {
     initialContentOffset = galleryView.collectionView.contentOffset
 
     applyOrientationTransforms()
-  }
-
-  open override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-    UIApplication.shared.setStatusBarHidden(statusBarHidden, with: .fade)
   }
 
   open func resetAssets() {
@@ -280,7 +274,7 @@ open class ImagePickerController: UIViewController {
   // MARK: - Helpers
 
   open override var prefersStatusBarHidden: Bool {
-    return true
+    return statusBarHidden
   }
 
   open func collapseGalleryView(_ completion: (() -> Void)?) {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -2,7 +2,7 @@ import UIKit
 import MediaPlayer
 import Photos
 
-@objc public protocol ImagePickerDelegate: class {
+@objc public protocol ImagePickerDelegate: NSObjectProtocol {
 
   func wrapperDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
@@ -69,7 +69,7 @@ open class ImagePickerController: UIViewController {
 
   var volume = AVAudioSession.sharedInstance().outputVolume
 
-  open weak var delegate: ImagePickerDelegate?
+  @objc open weak var delegate: ImagePickerDelegate?
   open var stack = ImageStack()
   open var imageLimit = 0
   open var preferredImageSize: CGSize?
@@ -91,13 +91,19 @@ open class ImagePickerController: UIViewController {
 
   // MARK: - Initialization
 
-  public required init(configuration: Configuration = Configuration()) {
+  @objc public required init(configuration: Configuration = Configuration()) {
     self.configuration = configuration
     super.init(nibName: nil, bundle: nil)
   }
 
+  public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    self.configuration = Configuration()
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+  
   public required init?(coder aDecoder: NSCoder) {
-    fatalError()
+    self.configuration = Configuration()
+    super.init(coder: aDecoder)
   }
 
   // MARK: - View lifecycle


### PR DESCRIPTION
This PR aims to restore Objective-C support by:
- [x] Adding the required `@objc` annotations
- [x] Moving the `Configuration` to an actual class (structs are not available in Obj-C)

It also fixes a deprecation warning caused by the deprecated `setStatusBarHidden:animation:` selector in favor of `prefersStatusBarHidden` that is used already but is now returning the actual value set by the instance property.

Let me know if you have any issues with these changes, thx!