### PR TITLE
Unowned refrence when taking picutre fix

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -333,7 +333,8 @@ open class ImagePickerController: UIViewController {
     isTakingPicture = true
     bottomContainer.pickerButton.isEnabled = false
     bottomContainer.stackView.startLoader()
-    let action: () -> Void = { [unowned self] in
+    let action: () -> Void = { [weak self] in
+      guard let `self` = self else { return }
       self.cameraController.takePicture { self.isTakingPicture = false }
     }
 


### PR DESCRIPTION
Hi,
While taking the picture on the controller and pressing photo button and cancel at the same time it crashed the library. Guess who does that? Of course our QA 😒 🤕 

So this is the fix. We tested it.

I have changed refrence type from `unowned` to `weak` and have added `guard` to check if self is still allocated.