### PR TITLE
Added config value for handling volume actions

### DIFF
--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -51,6 +51,7 @@ import UIKit
   @objc public var managesAudioSession = true
   @objc public var allowPinchToZoom = true
   @objc public var allowedOrientations = UIInterfaceOrientationMask.all
+  @objc public var allowVolumeButtonsToTakePicture = true
 
   // MARK: Images
   @objc public var indicatorView: UIView = {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -255,7 +255,8 @@ open class ImagePickerController: UIViewController {
   }
 
   @objc func volumeChanged(_ notification: Notification) {
-    guard let slider = volumeView.subviews.filter({ $0 is UISlider }).first as? UISlider,
+    guard configuration.allowVolumeButtonsToTakePicture,
+      let slider = volumeView.subviews.filter({ $0 is UISlider }).first as? UISlider,
       let userInfo = (notification as NSNotification).userInfo,
       let changeReason = userInfo["AVSystemController_AudioVolumeChangeReasonNotificationParameter"] as? String, changeReason == "ExplicitVolumeChange" else { return }
 


### PR DESCRIPTION
This will default to true to match iPhone behavior of taking pictures with the volume buttons, but it might be nice to turn this off.