### PR TITLE
Dismiss when only one photo requested and selected

### DIFF
--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -231,6 +231,11 @@ open class ImagePickerController: UIViewController {
       selector: #selector(adjustButtonTitle(_:)),
       name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
       object: nil)
+    
+    NotificationCenter.default.addObserver(self,
+                                           selector: #selector(dismissIfNeeded),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
+                                           object: nil)
 
     NotificationCenter.default.addObserver(self,
       selector: #selector(didReloadAssets(_:)),
@@ -270,6 +275,13 @@ open class ImagePickerController: UIViewController {
     let title = !sender.assets.isEmpty ?
       configuration.doneButtonTitle : configuration.cancelButtonTitle
     bottomContainer.doneButton.setTitle(title, for: UIControlState())
+  }
+  
+  @objc func dismissIfNeeded() {
+    // If only one image is requested and a push occures, automatically dismiss the ImagePicker
+    if imageLimit == 1 {
+      doneButtonDidPress()
+    }
   }
 
   // MARK: - Helpers


### PR DESCRIPTION
The ImagePicker should be dismissed when only one photo can be selected and the user did complete the action by chosing the photo of their choice.

It turned out in user testings, that the additional tap, which was needed prior my small alternation, caused confusion. Now, the photo selection process is one tap quicker.