### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ let imagePickerController = ImagePickerController()
 imagePickerController.imageLimit = 5
 ```
 
+### Permissions
+
+In order to use **ImagePicker**, one must grant permission to use the camera app and photo library by adding a string to the Info.plist file. To do this, right click the Info.plist file and choose Open As > Source Code.
+
+Then, add these lines to the dict tag
+  
+```plist
+<key>NSCameraUsageDescription</key>
+<string>${PRODUCT_NAME} camera usage</string>
+<key>NSPhotoLibraryUsageDescription</key>
+<string>${PRODUCT_NAME} photo library usage</string>
+```
+
 ### Optional bonus
 
 ##### Configuration


### PR DESCRIPTION
Added information about permissions to the README. When I first tried using the ImagePicker I got a "Terminated due to signal 9" error on the line

`self.present(imagePickerController, animated: true, completion: nil)`

The issue was that I forgot to include camera and photo library permissions. Thought it would be informative to add this information to the README. This was also requested in this [issue](https://github.com/hyperoslo/ImagePicker/issues/231).