### PR TITLE
Added the ability to save photos without loss of location and exif metadata, fixed several bugs

### DIFF
--- a/Demo/ImagePickerDemo/ImagePickerDemo.xcodeproj/project.pbxproj
+++ b/Demo/ImagePickerDemo/ImagePickerDemo.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 				29D699D61B70ABFC0021FA73 /* Frameworks */,
 				29D699D71B70ABFC0021FA73 /* Resources */,
 				F3EF51BCE509121FBC00640E /* [CP] Embed Pods Frameworks */,
-				EEE9A1733584FC13190615E2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -185,21 +184,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EEE9A1733584FC13190615E2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ImagePickerDemo/Pods-ImagePickerDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		F3EF51BCE509121FBC00640E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -212,7 +196,6 @@
 				"${BUILT_PRODUCTS_DIR}/ImagePicker/ImagePicker.framework",
 				"${BUILT_PRODUCTS_DIR}/Imaginary/Imaginary.framework",
 				"${BUILT_PRODUCTS_DIR}/Lightbox/Lightbox.framework",
-				"${BUILT_PRODUCTS_DIR}/SwiftHash/SwiftHash.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -221,7 +204,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ImagePicker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Imaginary.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lightbox.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftHash.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Demo/ImagePickerDemo/ImagePickerDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Demo/ImagePickerDemo/ImagePickerDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Demo/ImagePickerDemo/ImagePickerDemo/ViewController.swift
+++ b/Demo/ImagePickerDemo/ImagePickerDemo/ViewController.swift
@@ -1,6 +1,9 @@
 import UIKit
 import ImagePicker
 import Lightbox
+import CoreLocation
+import AVFoundation
+
 
 class ViewController: UIViewController, ImagePickerDelegate {
 
@@ -36,7 +39,7 @@ class ViewController: UIViewController, ImagePickerDelegate {
   }
 
   @objc func buttonTouched(button: UIButton) {
-    var config = Configuration()
+    let config = Configuration()
     config.doneButtonTitle = "Finish"
     config.noImagesTitle = "Sorry! There are no images here!"
     config.recordLocation = false
@@ -44,6 +47,8 @@ class ViewController: UIViewController, ImagePickerDelegate {
 
     let imagePicker = ImagePickerController(configuration: config)
     imagePicker.delegate = self
+    ImagePickerController.photoQuality = AVCaptureSession.Preset.photo
+
 
     present(imagePicker, animated: true, completion: nil)
   }
@@ -68,4 +73,32 @@ class ViewController: UIViewController, ImagePickerDelegate {
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [UIImage]) {
     imagePicker.dismiss(animated: true, completion: nil)
   }
+
+  // Called only if set value to ImagePickerController.photoQuality
+  func wrapperDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data, location: CLLocation?)]) {
+    guard images.count > 0 else { return }
+
+    self.parseImageData(imagePicker: imagePicker, images: images)
+  }
+  // Called only if set value to ImagePickerController.photoQuality
+  func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data, location: CLLocation?)]) {
+    guard images.count > 0 else { return }
+
+    self.parseImageData(imagePicker: imagePicker, images: images)
+  }
+
+  private func parseImageData(imagePicker: ImagePickerController, images: [(imageData: Data, location: CLLocation?)]) {
+
+    var lightboxImages = [LightboxImage]()
+
+    images.forEach { (image) in
+      print(image.location as Any)
+      if let image = UIImage(data: image.imageData, scale: 1.0) {
+        lightboxImages.append(LightboxImage(image: image))
+      }
+      let lightbox = LightboxController(images: lightboxImages, startIndex: 0)
+      imagePicker.present(lightbox, animated: true, completion: nil)
+    }
+  }
+
 }

--- a/Demo/ImagePickerDemo/Podfile.lock
+++ b/Demo/ImagePickerDemo/Podfile.lock
@@ -1,32 +1,36 @@
 PODS:
-  - Cache (4.0.2):
-    - SwiftHash (~> 2.0.0)
-  - Hue (3.0.0)
-  - ImagePicker (3.0.0)
-  - Imaginary (3.0.0):
+  - Cache (4.2.0)
+  - Hue (3.0.1)
+  - ImagePicker (3.1.5)
+  - Imaginary (3.0.3):
     - Cache (~> 4.0)
-  - Lightbox (2.0.0):
+  - Lightbox (2.1.2):
     - Hue (~> 3.0)
     - Imaginary (~> 3.0)
-  - SwiftHash (2.0.0)
 
 DEPENDENCIES:
   - Hue
   - ImagePicker (from `../../`)
   - Lightbox
 
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - Cache
+    - Hue
+    - Imaginary
+    - Lightbox
+
 EXTERNAL SOURCES:
   ImagePicker:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  Cache: 363b6899cee63c82ccbd291e64a6c202abc17a88
-  Hue: b8fe1e43eef13631331eebecb2198b68e2622f95
-  ImagePicker: f8a3ce52e587b55f58aef2d83d894ed6f7820f51
-  Imaginary: 2765d293d425cbed3b07fa11642554cbaebe913d
-  Lightbox: 83ec9f4aba4c79fc7bb9bcd263386df9969f09bb
-  SwiftHash: d2e09b13495447178cdfb8e46e54a5c46f15f5a9
+  Cache: f28f8dd64b632155aabf9b3906b036a659048251
+  Hue: 93e852fa6211ab35922ad8c293f51c43d6c79eb2
+  ImagePicker: cde0951760bd22b40d73add6ad7e0c9c6ab68d88
+  Imaginary: 9b45836a5af881f452a86e0a1215772ae4712d00
+  Lightbox: 2dc267df8be2285bc7724cb11cbbf4aaaf59dced
 
 PODFILE CHECKSUM: 702c1e0df019fe44ce740e86904dd384d55aefbe
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.0

--- a/ImagePicker.podspec
+++ b/ImagePicker.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "ImagePicker"
   s.summary          = "Reinventing the way ImagePicker works."
-  s.version          = "3.1.0"
+  s.version          = `git describe --abbrev=0 --tags`
   s.homepage         = "https://github.com/hyperoslo/ImagePicker"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }

--- a/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -66,4 +66,32 @@ open class AssetManager {
     }
     return images
   }
+
+  open static func resolveAssets(_ assets: [PHAsset],imagesClosers: @escaping ([(imageData: Data, location: CLLocation?)])->()) {
+    let imageManager = PHImageManager.default()
+    let requestOptions = PHImageRequestOptions()
+    requestOptions.isSynchronous = true
+
+    var imagesData = [(imageData: Data,location: CLLocation?)]()
+
+    for asset in assets {
+      let options = PHContentEditingInputRequestOptions()
+      options.isNetworkAccessAllowed = true
+      asset.requestContentEditingInput(with: options) { (contentEditingInput: PHContentEditingInput?, _) -> Void in
+
+        let optionsRequest = PHImageRequestOptions()
+        optionsRequest.version = .original
+        optionsRequest.isSynchronous = true
+        imageManager.requestImageData(for: asset, options: optionsRequest, resultHandler: { (data, string, orientation, info) in
+          if let data = data {
+            imagesData.append((data, contentEditingInput!.location))
+            if (imagesData.count == assets.count) {
+              imagesClosers(imagesData)
+            }
+          }
+        })
+      }
+    }
+  }
+
 }

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -98,10 +98,12 @@ open class BottomContainerView: UIView {
     } else {
       delegate?.doneButtonDidPress()
     }
+    self.isUserInteractionEnabled = false
   }
 
   @objc func handleTapGestureRecognizer(_ recognizer: UITapGestureRecognizer) {
     delegate?.imageStackViewDidPress()
+    self.isUserInteractionEnabled = false
   }
 
   fileprivate func animateImageView(_ imageView: UIImageView) {

--- a/Source/BottomView/ButtonPicker.swift
+++ b/Source/BottomView/ButtonPicker.swift
@@ -54,19 +54,19 @@ class ButtonPicker: UIButton {
 
   func subscribe() {
     NotificationCenter.default.addObserver(self,
-      selector: #selector(recalculatePhotosCount(_:)),
-      name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidPush),
-      object: nil)
+                                           selector: #selector(recalculatePhotosCount(_:)),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidPush),
+                                           object: nil)
 
     NotificationCenter.default.addObserver(self,
-      selector: #selector(recalculatePhotosCount(_:)),
-      name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
-      object: nil)
+                                           selector: #selector(recalculatePhotosCount(_:)),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
+                                           object: nil)
 
     NotificationCenter.default.addObserver(self,
-      selector: #selector(recalculatePhotosCount(_:)),
-      name: NSNotification.Name(rawValue: ImageStack.Notifications.stackDidReload),
-      object: nil)
+                                           selector: #selector(recalculatePhotosCount(_:)),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.stackDidReload),
+                                           object: nil)
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -81,6 +81,8 @@ class ButtonPicker: UIButton {
     accessibilityLabel = "Take photo"
     addTarget(self, action: #selector(pickerButtonDidPress(_:)), for: .touchUpInside)
     addTarget(self, action: #selector(pickerButtonDidHighlight(_:)), for: .touchDown)
+    addTarget(self, action: #selector(pickerButtonDidDragOutside(_:)), for: .touchDragOutside)
+
   }
 
   // MARK: - Actions
@@ -99,6 +101,11 @@ class ButtonPicker: UIButton {
 
   @objc func pickerButtonDidHighlight(_ button: UIButton) {
     numberLabel.textColor = UIColor.white
-    backgroundColor = UIColor(red: 0.3, green: 0.3, blue: 0.3, alpha: 1)
+    backgroundColor = UIColor(red:0.3, green:0.3, blue:0.3, alpha:1)
+  }
+
+  @objc func pickerButtonDidDragOutside(_ button: UIButton) {
+    numberLabel.textColor = UIColor.black
+    backgroundColor = UIColor.white
   }
 }

--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -210,12 +210,10 @@ class CameraMan {
         }
         if let attached = self.attachEXIFtoImage(image: imageData, EXIF: currentProperties) {
           do {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "Y-M-dd_HH-mm-ss"
-            let time = formatter.string(from: Date())
+
             let fileName = NSUUID().uuidString + "imagePicker.jpg"
             if let fullURL = NSURL.fileURL(withPathComponents: [NSTemporaryDirectory(), fileName]) {
-              try! attached.write(to: fullURL)
+              try attached.write(to: fullURL)
               let request = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: fullURL)
               request?.creationDate = Date()
               request?.location = location

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -4,18 +4,15 @@ import Photos
 
 
 
-@objc public protocol ImagePickerDelegate: NSObjectProtocol {
+public protocol ImagePickerDelegate: NSObjectProtocol {
 
   func wrapperDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func cancelButtonDidPress(_ imagePicker: ImagePickerController)
-
+  func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)])
+  func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)])
 }
 
-extension ImagePickerDelegate {
-  func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)]) {}
-  func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)]) {}
-}
 
 
 open class ImagePickerController: UIViewController {
@@ -78,7 +75,7 @@ open class ImagePickerController: UIViewController {
 
   var volume = AVAudioSession.sharedInstance().outputVolume
 
-  @objc open weak var delegate: ImagePickerDelegate?
+  open weak var delegate: ImagePickerDelegate?
   open static var photoQuality: AVCaptureSession.Preset?
   open var stack = ImageStack()
   open var imageLimit = 0

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -6,14 +6,21 @@ import Photos
 
 public protocol ImagePickerDelegate: NSObjectProtocol {
 
+
   func wrapperDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func cancelButtonDidPress(_ imagePicker: ImagePickerController)
+
+  /// Called only if set value to ImagePickerController.photoQuality
   func wrapperDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data,location: CLLocation?)])
+  /// Called only if set value to ImagePickerController.photoQuality
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data,location: CLLocation?)])
 }
 
-
+public extension ImagePickerDelegate {
+  func wrapperDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data,location: CLLocation?)]) {}
+  func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data,location: CLLocation?)]) {}
+}
 
 open class ImagePickerController: UIViewController {
 

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -9,8 +9,8 @@ public protocol ImagePickerDelegate: NSObjectProtocol {
   func wrapperDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func cancelButtonDidPress(_ imagePicker: ImagePickerController)
-  func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)])
-  func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)])
+  func wrapperDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data,location: CLLocation?)])
+  func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [(imageData: Data,location: CLLocation?)])
 }
 
 
@@ -383,7 +383,9 @@ extension ImagePickerController: BottomContainerViewDelegate {
         (images: [(imageData: Data,location: CLLocation?)]) in
 
         self?.clearTempData()
-        self?.delegate?.doneButtonDidPress(images: images)
+        if let self_ = self {
+          self?.delegate?.doneButtonDidPress(self_, images: images)
+        }
       })
     } else {
       var images: [UIImage]
@@ -407,7 +409,9 @@ extension ImagePickerController: BottomContainerViewDelegate {
       AssetManager.resolveAssets(stack.assets, imagesClosers: { [weak self]
         (images: [(imageData: Data,location: CLLocation?)]) in
         self?.clearTempData()
-        self?.delegate?.wrapperDidPress(images: images)
+        if let self_ = self {
+          self?.delegate?.wrapperDidPress(self_, images: images)
+        }
       })
     } else {
       var images: [UIImage]


### PR DESCRIPTION
1. Added the ability to save photos without loss of location and exif metadata
(Now the photo album stores the data. (which store the exif metadata and the gps coordinates) not UIImage. 
If you set the quality of the photo (ImagePickerController.photoQuality = AVCaptureSession.Preset.photo), then after creating the snapshot, we will call the delegates
(func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)])
  func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)])), which will return the data. If the picture quality is not set in advance, the old delegate method will be called
2. Fixed bug when clicking and dragging(outside the photo button)
3. Fixed bugs when clicking the Done/Cancel/PhotoStack button again