### PR TITLE
Upgrade to Swift 4.2

### DIFF
--- a/ImagePicker.podspec
+++ b/ImagePicker.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "ImagePicker"
   s.summary          = "Reinventing the way ImagePicker works."
-  s.version          = "3.1.0"
+  s.version          = "3.2.0"
   s.homepage         = "https://github.com/hyperoslo/ImagePicker"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*'
   s.resource_bundles = { 'ImagePicker' => ['Images/*.{png}'] }
   s.frameworks = 'AVFoundation'
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
 end

--- a/ImagePicker.xcodeproj/project.pbxproj
+++ b/ImagePicker.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		D5D370C31C44FD1600690C0A /* OFF@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5D370BD1C44FD1600690C0A /* OFF@3x.png */; };
 		D5D370C41C44FD1600690C0A /* ON@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5D370BE1C44FD1600690C0A /* ON@3x.png */; };
 		D5D370C51C44FD1600690C0A /* selectedImageGallery@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D5D370BF1C44FD1600690C0A /* selectedImageGallery@3x.png */; };
-		D5DC59961C201BE1003BD79B /* ImagePicker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5DC598B1C201BE1003BD79B /* ImagePicker.framework */; };
 		D5DC59C21C201CC4003BD79B /* BottomContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59AD1C201CC4003BD79B /* BottomContainerView.swift */; };
 		D5DC59C31C201CC4003BD79B /* ButtonPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59AE1C201CC4003BD79B /* ButtonPicker.swift */; };
 		D5DC59C41C201CC4003BD79B /* ImageStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59AF1C201CC4003BD79B /* ImageStack.swift */; };
@@ -31,20 +30,9 @@
 		D5DC59CB1C201CC4003BD79B /* ImageGalleryViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59B91C201CC4003BD79B /* ImageGalleryViewDataSource.swift */; };
 		D5DC59CC1C201CC4003BD79B /* ImagePickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59BA1C201CC4003BD79B /* ImagePickerController.swift */; };
 		D5DC59CE1C201CC4003BD79B /* TopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59BD1C201CC4003BD79B /* TopView.swift */; };
-		D5DC59CF1C201CCC003BD79B /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DC59A71C201CC4003BD79B /* Tests.swift */; };
 		DC197E381E945FA500F2A7D1 /* video@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = DC197E371E945FA500F2A7D1 /* video@3x.png */; };
 		DC197E3C1E94DA5600F2A7D1 /* VideoInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC197E3B1E94DA5600F2A7D1 /* VideoInfoView.swift */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		D5DC59971C201BE1003BD79B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D5DC59821C201BE1003BD79B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5DC598A1C201BE1003BD79B;
-			remoteInfo = ImagePicker;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		39D1340F1CAC4B4E00EA2ECE /* AssetManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetManager.swift; sourceTree = "<group>"; };
@@ -59,9 +47,6 @@
 		D5D370BE1C44FD1600690C0A /* ON@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ON@3x.png"; sourceTree = "<group>"; };
 		D5D370BF1C44FD1600690C0A /* selectedImageGallery@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "selectedImageGallery@3x.png"; sourceTree = "<group>"; };
 		D5DC598B1C201BE1003BD79B /* ImagePicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ImagePicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5DC59951C201BE1003BD79B /* ImagePicker-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ImagePicker-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D5DC59A61C201CC4003BD79B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D5DC59A71C201CC4003BD79B /* Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		D5DC59A91C201CC4003BD79B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5DC59AD1C201CC4003BD79B /* BottomContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomContainerView.swift; sourceTree = "<group>"; };
 		D5DC59AE1C201CC4003BD79B /* ButtonPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonPicker.swift; sourceTree = "<group>"; };
@@ -87,14 +72,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D5DC59921C201BE1003BD79B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D5DC59961C201BE1003BD79B /* ImagePicker.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -116,7 +93,6 @@
 			isa = PBXGroup;
 			children = (
 				D5D370B91C44FD1600690C0A /* Images */,
-				D5DC59A51C201CC4003BD79B /* Tests */,
 				D5DC59A81C201CC4003BD79B /* SupportFiles */,
 				D5DC59AA1C201CC4003BD79B /* Source */,
 				D5DC598C1C201BE1003BD79B /* Products */,
@@ -129,18 +105,8 @@
 			isa = PBXGroup;
 			children = (
 				D5DC598B1C201BE1003BD79B /* ImagePicker.framework */,
-				D5DC59951C201BE1003BD79B /* ImagePicker-iOS-Tests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		D5DC59A51C201CC4003BD79B /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				D5DC59A61C201CC4003BD79B /* Info.plist */,
-				D5DC59A71C201CC4003BD79B /* Tests.swift */,
-			);
-			path = Tests;
 			sourceTree = "<group>";
 		};
 		D5DC59A81C201CC4003BD79B /* SupportFiles */ = {
@@ -248,24 +214,6 @@
 			productReference = D5DC598B1C201BE1003BD79B /* ImagePicker.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D5DC59941C201BE1003BD79B /* ImagePicker-iOS-Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D5DC59A21C201BE1003BD79B /* Build configuration list for PBXNativeTarget "ImagePicker-iOS-Tests" */;
-			buildPhases = (
-				D5DC59911C201BE1003BD79B /* Sources */,
-				D5DC59921C201BE1003BD79B /* Frameworks */,
-				D5DC59931C201BE1003BD79B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D5DC59981C201BE1003BD79B /* PBXTargetDependency */,
-			);
-			name = "ImagePicker-iOS-Tests";
-			productName = ImagePickerTests;
-			productReference = D5DC59951C201BE1003BD79B /* ImagePicker-iOS-Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -273,16 +221,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Hyper Interaktiv AS";
 				TargetAttributes = {
 					D5DC598A1C201BE1003BD79B = {
 						CreatedOnToolsVersion = 7.2;
 						DevelopmentTeam = 9J5NKKT78R;
-						LastSwiftMigration = 0800;
-					};
-					D5DC59941C201BE1003BD79B = {
-						DevelopmentTeam = QQJ8AA32HJ;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -299,7 +244,6 @@
 			projectRoot = "";
 			targets = (
 				D5DC598A1C201BE1003BD79B /* ImagePicker-iOS */,
-				D5DC59941C201BE1003BD79B /* ImagePicker-iOS-Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -316,13 +260,6 @@
 				DC197E381E945FA500F2A7D1 /* video@3x.png in Resources */,
 				D5D370C11C44FD1600690C0A /* cameraIcon@3x.png in Resources */,
 				D5D370C31C44FD1600690C0A /* OFF@3x.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D5DC59931C201BE1003BD79B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -370,23 +307,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D5DC59911C201BE1003BD79B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D5DC59CF1C201CCC003BD79B /* Tests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		D5DC59981C201BE1003BD79B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D5DC598A1C201BE1003BD79B /* ImagePicker-iOS */;
-			targetProxy = D5DC59971C201BE1003BD79B /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		D5DC599D1C201BE1003BD79B /* Debug */ = {
@@ -401,12 +322,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -439,7 +362,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -458,12 +381,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -489,7 +414,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -513,6 +438,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ImagePicker;
 				PRODUCT_NAME = ImagePicker;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -532,30 +458,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ImagePicker;
 				PRODUCT_NAME = ImagePicker;
 				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		D5DC59A31C201BE1003BD79B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = QQJ8AA32HJ;
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ImagePickerTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
-			};
-			name = Debug;
-		};
-		D5DC59A41C201BE1003BD79B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEVELOPMENT_TEAM = QQJ8AA32HJ;
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.ImagePickerTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -576,15 +479,6 @@
 			buildConfigurations = (
 				D5DC59A01C201BE1003BD79B /* Debug */,
 				D5DC59A11C201BE1003BD79B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D5DC59A21C201BE1003BD79B /* Build configuration list for PBXNativeTarget "ImagePicker-iOS-Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D5DC59A31C201BE1003BD79B /* Debug */,
-				D5DC59A41C201BE1003BD79B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ImagePicker.xcodeproj/xcshareddata/xcschemes/ImagePicker-iOS.xcscheme
+++ b/ImagePicker.xcodeproj/xcshareddata/xcschemes/ImagePicker-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -4,7 +4,7 @@ import Photos
 
 open class AssetManager {
 
-  open static func getImage(_ name: String) -> UIImage {
+  public static func getImage(_ name: String) -> UIImage {
     let traitCollection = UITraitCollection(displayScale: 3)
     var bundle = Bundle(for: AssetManager.self)
 
@@ -15,7 +15,7 @@ open class AssetManager {
     return UIImage(named: name, in: bundle, compatibleWith: traitCollection) ?? UIImage()
   }
 
-  open static func fetch(withConfiguration configuration: Configuration, _ completion: @escaping (_ assets: [PHAsset]) -> Void) {
+  public static func fetch(withConfiguration configuration: Configuration, _ completion: @escaping (_ assets: [PHAsset]) -> Void) {
     guard PHPhotoLibrary.authorizationStatus() == .authorized else { return }
 
     DispatchQueue.global(qos: .background).async {
@@ -36,7 +36,7 @@ open class AssetManager {
     }
   }
 
-  open static func resolveAsset(_ asset: PHAsset, size: CGSize = CGSize(width: 720, height: 1280), shouldPreferLowRes: Bool = false, completion: @escaping (_ image: UIImage?) -> Void) {
+  public static func resolveAsset(_ asset: PHAsset, size: CGSize = CGSize(width: 720, height: 1280), shouldPreferLowRes: Bool = false, completion: @escaping (_ image: UIImage?) -> Void) {
     let imageManager = PHImageManager.default()
     let requestOptions = PHImageRequestOptions()
     requestOptions.deliveryMode = shouldPreferLowRes ? .fastFormat : .highQualityFormat
@@ -51,7 +51,7 @@ open class AssetManager {
     }
   }
 
-  open static func resolveAssets(_ assets: [PHAsset], size: CGSize = CGSize(width: 720, height: 1280)) -> [UIImage] {
+  public static func resolveAssets(_ assets: [PHAsset], size: CGSize = CGSize(width: 720, height: 1280)) -> [UIImage] {
     let imageManager = PHImageManager.default()
     let requestOptions = PHImageRequestOptions()
     requestOptions.isSynchronous = true

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -18,7 +18,7 @@ open class BottomContainerView: UIView {
 
   lazy var pickerButton: ButtonPicker = { [unowned self] in
     let pickerButton = ButtonPicker(configuration: self.configuration)
-    pickerButton.setTitleColor(UIColor.white, for: UIControlState())
+    pickerButton.setTitleColor(UIColor.white, for: UIControl.State())
     pickerButton.delegate = self
     pickerButton.numberLabel.isHidden = !self.configuration.showsImageCountLabel
 
@@ -37,7 +37,7 @@ open class BottomContainerView: UIView {
 
   open lazy var doneButton: UIButton = { [unowned self] in
     let button = UIButton()
-    button.setTitle(self.configuration.cancelButtonTitle, for: UIControlState())
+    button.setTitle(self.configuration.cancelButtonTitle, for: UIControl.State())
     button.titleLabel?.font = self.configuration.doneButton
     button.addTarget(self, action: #selector(doneButtonDidPress(_:)), for: .touchUpInside)
 

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -59,11 +59,11 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     let button = UIButton(type: .system)
     let title = NSAttributedString(string: self.configuration.settingsTitle,
       attributes: [
-        NSAttributedStringKey.font: self.configuration.settingsFont,
-        NSAttributedStringKey.foregroundColor: self.configuration.settingsColor
+        NSAttributedString.Key.font: self.configuration.settingsFont,
+        NSAttributedString.Key.foregroundColor: self.configuration.settingsColor
       ])
 
-    button.setAttributedTitle(title, for: UIControlState())
+    button.setAttributedTitle(title, for: UIControl.State())
     button.contentEdgeInsets = UIEdgeInsets(top: 5.0, left: 10.0, bottom: 5.0, right: 10.0)
     button.sizeToFit()
     button.layer.borderColor = self.configuration.settingsColor.cgColor
@@ -187,7 +187,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
 
   @objc func settingsButtonDidTap() {
     DispatchQueue.main.async {
-      if let settingsURL = URL(string: UIApplicationOpenSettingsURLString) {
+      if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
         UIApplication.shared.openURL(settingsURL)
       }
     }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -285,8 +285,6 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
 
   @objc func pinchGestureRecognizerHandler(_ gesture: UIPinchGestureRecognizer) {
     switch gesture.state {
-    case .began:
-      fallthrough
     case .changed:
       zoomTo(gesture.scale)
     case .ended:

--- a/Source/Extensions/ConstraintsSetup.swift
+++ b/Source/Extensions/ConstraintsSetup.swift
@@ -6,7 +6,7 @@ extension BottomContainerView {
 
   func setupConstraints() {
 
-    for attribute: NSLayoutAttribute in [.centerX, .centerY] {
+    for attribute: NSLayoutConstraint.Attribute in [.centerX, .centerY] {
       addConstraint(NSLayoutConstraint(item: pickerButton, attribute: attribute,
         relatedBy: .equal, toItem: self, attribute: attribute,
         multiplier: 1, constant: 0))
@@ -16,13 +16,13 @@ extension BottomContainerView {
         multiplier: 1, constant: 0))
     }
 
-    for attribute: NSLayoutAttribute in [.width, .left, .top] {
+    for attribute: NSLayoutConstraint.Attribute in [.width, .left, .top] {
       addConstraint(NSLayoutConstraint(item: topSeparator, attribute: attribute,
         relatedBy: .equal, toItem: self, attribute: attribute,
         multiplier: 1, constant: 0))
     }
 
-    for attribute: NSLayoutAttribute in [.width, .height] {
+    for attribute: NSLayoutConstraint.Attribute in [.width, .height] {
       addConstraint(NSLayoutConstraint(item: pickerButton, attribute: attribute,
         relatedBy: .equal, toItem: nil, attribute: .notAnAttribute,
         multiplier: 1, constant: ButtonPicker.Dimensions.buttonSize))
@@ -102,8 +102,8 @@ extension TopView {
 extension ImagePickerController {
 
   func setupConstraints() {
-    let attributes: [NSLayoutAttribute] = [.bottom, .right, .width]
-    let topViewAttributes: [NSLayoutAttribute] = [.left, .width]
+    let attributes: [NSLayoutConstraint.Attribute] = [.bottom, .right, .width]
+    let topViewAttributes: [NSLayoutConstraint.Attribute] = [.left, .width]
 
     for attribute in attributes {
       view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: attribute,
@@ -111,7 +111,7 @@ extension ImagePickerController {
         multiplier: 1, constant: 0))
     }
 
-    for attribute: NSLayoutAttribute in [.left, .top, .width] {
+    for attribute: NSLayoutConstraint.Attribute in [.left, .top, .width] {
       view.addConstraint(NSLayoutConstraint(item: cameraController.view, attribute: attribute,
         relatedBy: .equal, toItem: view, attribute: attribute,
         multiplier: 1, constant: 0))
@@ -164,7 +164,7 @@ extension ImageGalleryViewCell {
 
   func setupConstraints() {
 
-    for attribute: NSLayoutAttribute in [.width, .height, .centerX, .centerY] {
+    for attribute: NSLayoutConstraint.Attribute in [.width, .height, .centerX, .centerY] {
       addConstraint(NSLayoutConstraint(item: imageView, attribute: attribute,
         relatedBy: .equal, toItem: self, attribute: attribute,
         multiplier: 1, constant: 0))
@@ -179,7 +179,7 @@ extension ImageGalleryViewCell {
 extension ButtonPicker {
 
   func setupConstraints() {
-    let attributes: [NSLayoutAttribute] = [.centerX, .centerY]
+    let attributes: [NSLayoutConstraint.Attribute] = [.centerX, .centerY]
 
     for attribute in attributes {
       addConstraint(NSLayoutConstraint(item: numberLabel, attribute: attribute,

--- a/Source/Extensions/ConstraintsSetup.swift
+++ b/Source/Extensions/ConstraintsSetup.swift
@@ -134,7 +134,7 @@ extension ImagePickerController {
                                             attribute: .top,
                                             multiplier: 1, constant: 0))
     }
-    
+
     if #available(iOS 11.0, *) {
       let heightPadding = UIApplication.shared.keyWindow!.safeAreaInsets.bottom
       view.addConstraint(NSLayoutConstraint(item: bottomContainer, attribute: .height,

--- a/Source/ImageGallery/ImageGalleryViewDataSource.swift
+++ b/Source/ImageGallery/ImageGalleryViewDataSource.swift
@@ -24,7 +24,7 @@ extension ImageGalleryView: UICollectionViewDataSource {
         if (indexPath as NSIndexPath).row == 0 && self.shouldTransform {
           cell.transform = CGAffineTransform(scaleX: 0, y: 0)
 
-          UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: UIViewAnimationOptions(), animations: {
+          UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: UIView.AnimationOptions(), animations: {
             cell.transform = CGAffineTransform.identity
             }) { _ in }
 

--- a/Source/ImageGallery/ImageGalleryViewDataSource.swift
+++ b/Source/ImageGallery/ImageGalleryViewDataSource.swift
@@ -26,7 +26,7 @@ extension ImageGalleryView: UICollectionViewDataSource {
 
           UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 1, options: UIView.AnimationOptions(), animations: {
             cell.transform = CGAffineTransform.identity
-            }) { _ in }
+          }, completion: nil)
 
           self.shouldTransform = false
         }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -84,7 +84,7 @@ open class ImagePickerController: UIViewController {
   open var doneButtonTitle: String? {
     didSet {
       if let doneButtonTitle = doneButtonTitle {
-        bottomContainer.doneButton.setTitle(doneButtonTitle, for: UIControlState())
+        bottomContainer.doneButton.setTitle(doneButtonTitle, for: UIControl.State())
       }
     }
   }
@@ -117,7 +117,7 @@ open class ImagePickerController: UIViewController {
     }
 
     view.addSubview(volumeView)
-    view.sendSubview(toBack: volumeView)
+    view.sendSubviewToBack(volumeView)
 
     view.backgroundColor = UIColor.white
     view.backgroundColor = configuration.mainColor
@@ -161,8 +161,8 @@ open class ImagePickerController: UIViewController {
 
     applyOrientationTransforms()
 
-    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification,
-                                    bottomContainer);
+    UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
+                                    argument: bottomContainer);
   }
 
   open func resetAssets() {
@@ -190,7 +190,7 @@ open class ImagePickerController: UIViewController {
     let alertController = UIAlertController(title: configuration.requestPermissionTitle, message: configuration.requestPermissionMessage, preferredStyle: .alert)
 
     let alertAction = UIAlertAction(title: configuration.OKButtonTitle, style: .default) { _ in
-      if let settingsURL = URL(string: UIApplicationOpenSettingsURLString) {
+      if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
         UIApplication.shared.openURL(settingsURL)
       }
     }
@@ -252,7 +252,7 @@ open class ImagePickerController: UIViewController {
 
     NotificationCenter.default.addObserver(self,
       selector: #selector(handleRotation(_:)),
-      name: NSNotification.Name.UIDeviceOrientationDidChange,
+      name: UIDevice.orientationDidChangeNotification,
       object: nil)
   }
 
@@ -277,7 +277,7 @@ open class ImagePickerController: UIViewController {
 
     let title = !sender.assets.isEmpty ?
       configuration.doneButtonTitle : configuration.cancelButtonTitle
-    bottomContainer.doneButton.setTitle(title, for: UIControlState())
+    bottomContainer.doneButton.setTitle(title, for: UIControl.State())
   }
   
   @objc func dismissIfNeeded() {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -161,8 +161,7 @@ open class ImagePickerController: UIViewController {
 
     applyOrientationTransforms()
 
-    UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged,
-                                    argument: bottomContainer);
+    UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: bottomContainer)
   }
 
   open func resetAssets() {

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -100,7 +100,7 @@ open class ImagePickerController: UIViewController {
     self.configuration = Configuration()
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }
-  
+
   public required init?(coder aDecoder: NSCoder) {
     self.configuration = Configuration()
     super.init(coder: aDecoder)
@@ -234,7 +234,7 @@ open class ImagePickerController: UIViewController {
       selector: #selector(adjustButtonTitle(_:)),
       name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
       object: nil)
-    
+
     NotificationCenter.default.addObserver(self,
                                            selector: #selector(dismissIfNeeded),
                                            name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
@@ -279,7 +279,7 @@ open class ImagePickerController: UIViewController {
       configuration.doneButtonTitle : configuration.cancelButtonTitle
     bottomContainer.doneButton.setTitle(title, for: UIControl.State())
   }
-  
+
   @objc func dismissIfNeeded() {
     // If only one image is requested and a push occures, automatically dismiss the ImagePicker
     if imageLimit == 1 {

--- a/Source/TopView/TopView.swift
+++ b/Source/TopView/TopView.swift
@@ -21,10 +21,10 @@ open class TopView: UIView {
 
   open lazy var flashButton: UIButton = { [unowned self] in
     let button = UIButton()
-    button.setImage(AssetManager.getImage("AUTO"), for: UIControlState())
-    button.setTitle("AUTO", for: UIControlState())
+    button.setImage(AssetManager.getImage("AUTO"), for: UIControl.State())
+    button.setTitle("AUTO", for: UIControl.State())
     button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: 0)
-    button.setTitleColor(UIColor.white, for: UIControlState())
+    button.setTitleColor(UIColor.white, for: UIControl.State())
     button.setTitleColor(UIColor.white, for: .highlighted)
     button.titleLabel?.font = self.configuration.flashButton
     button.addTarget(self, action: #selector(flashButtonDidPress(_:)), for: .touchUpInside)
@@ -39,7 +39,7 @@ open class TopView: UIView {
     let button = UIButton()
     button.accessibilityLabel = ""
     button.accessibilityHint = "Double-tap to rotate camera"
-    button.setImage(AssetManager.getImage("cameraIcon"), for: UIControlState())
+    button.setImage(AssetManager.getImage("cameraIcon"), for: UIControl.State())
     button.addTarget(self, action: #selector(rotateCameraButtonDidPress(_:)), for: .touchUpInside)
     button.imageView?.contentMode = .center
 
@@ -96,18 +96,18 @@ open class TopView: UIView {
 
     switch currentFlashIndex {
     case 1:
-      button.setTitleColor(UIColor(red: 0.98, green: 0.98, blue: 0.45, alpha: 1), for: UIControlState())
+      button.setTitleColor(UIColor(red: 0.98, green: 0.98, blue: 0.45, alpha: 1), for: UIControl.State())
       button.setTitleColor(UIColor(red: 0.52, green: 0.52, blue: 0.24, alpha: 1), for: .highlighted)
 
     default:
-      button.setTitleColor(UIColor.white, for: UIControlState())
+      button.setTitleColor(UIColor.white, for: UIControl.State())
       button.setTitleColor(UIColor.white, for: .highlighted)
     }
 
     let newTitle = flashButtonTitles[currentFlashIndex]
 
-    button.setImage(AssetManager.getImage(newTitle), for: UIControlState())
-    button.setTitle(newTitle, for: UIControlState())
+    button.setImage(AssetManager.getImage(newTitle), for: UIControl.State())
+    button.setTitle(newTitle, for: UIControl.State())
     button.accessibilityLabel = "Flash mode is \(newTitle)"
 
     delegate?.flashButtonDidPress(newTitle)


### PR DESCRIPTION
This migrates the ImagePicker source to Swift 4.2.

A fresh clone of the project will not actually build the test scheme locally as there are references to files which are missing. I have removed these but if anyone has any objections to that I am happy to revert this change.

There are some SwiftLint tidy ups which consist mostly of whitespace removal, trailing closure syntax and static declarations. I hope these are in keeping with the style guide but I'm happy to remove them if they violate any guide rules.