### PR TITLE
Renaming Configuration class to ImagePickerConfiguration

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -24,7 +24,7 @@ open class AssetManager {
     return UIImage(named: name, in: bundle, compatibleWith: traitCollection) ?? UIImage()
   }
 
-  public static func fetch(withConfiguration configuration: Configuration, _ completion: @escaping (_ assets: [PHAsset]) -> Void) {
+  public static func fetch(withConfiguration configuration: ImagePickerConfiguration, _ completion: @escaping (_ assets: [PHAsset]) -> Void) {
     guard PHPhotoLibrary.authorizationStatus() == .authorized else { return }
 
     DispatchQueue.global(qos: .background).async {

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -14,7 +14,7 @@ open class BottomContainerView: UIView {
     static let height: CGFloat = 101
   }
 
-  var configuration = Configuration()
+  var configuration = ImagePickerConfiguration()
 
   lazy var pickerButton: ButtonPicker = { [unowned self] in
     let pickerButton = ButtonPicker(configuration: self.configuration)
@@ -65,7 +65,7 @@ open class BottomContainerView: UIView {
 
   // MARK: Initializers
 
-  public init(configuration: Configuration? = nil) {
+  public init(configuration: ImagePickerConfiguration? = nil) {
     if let configuration = configuration {
       self.configuration = configuration
     }

--- a/Source/BottomView/ButtonPicker.swift
+++ b/Source/BottomView/ButtonPicker.swift
@@ -13,7 +13,7 @@ class ButtonPicker: UIButton {
     static let buttonBorderSize: CGFloat = 68
   }
 
-  var configuration = Configuration()
+  var configuration = ImagePickerConfiguration()
 
   lazy var numberLabel: UILabel = { [unowned self] in
     let label = UILabel()
@@ -27,7 +27,7 @@ class ButtonPicker: UIButton {
 
   // MARK: - Initializers
 
-  public init(configuration: Configuration? = nil) {
+  public init(configuration: ImagePickerConfiguration? = nil) {
     if let configuration = configuration {
       self.configuration = configuration
     }

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -11,7 +11,7 @@ protocol CameraViewDelegate: class {
 
 class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate {
 
-  var configuration = Configuration()
+  var configuration = ImagePickerConfiguration()
 
   lazy var blurView: UIVisualEffectView = { [unowned self] in
     let effect = UIBlurEffect(style: .dark)
@@ -102,7 +102,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
   private var currentZoomFactor: CGFloat = 1.0
   private var previousZoomFactor: CGFloat = 1.0
 
-  public init(configuration: Configuration? = nil) {
+  public init(configuration: ImagePickerConfiguration? = nil) {
     if let configuration = configuration {
       self.configuration = configuration
     }

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import UIKit
 
-@objc public class Configuration: NSObject {
+@objc public class ImagePickerConfiguration: NSObject {
 
   // MARK: Colors
 
@@ -67,7 +67,7 @@ import UIKit
 }
 
 // MARK: - Orientation
-extension Configuration {
+extension ImagePickerConfiguration {
 
   @objc public var rotationTransform: CGAffineTransform {
     let currentOrientation = UIDevice.current.orientation

--- a/Source/ImageGallery/ImageGalleryLayout.swift
+++ b/Source/ImageGallery/ImageGalleryLayout.swift
@@ -2,9 +2,9 @@ import UIKit
 
 class ImageGalleryLayout: UICollectionViewFlowLayout {
 
-  let configuration: Configuration
+  let configuration: ImagePickerConfiguration
 
-  init(configuration: Configuration) {
+  init(configuration: ImagePickerConfiguration) {
     self.configuration = configuration
     super.init()
   }

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -26,7 +26,7 @@ open class ImageGalleryView: UIView {
     static let galleryBarHeight: CGFloat = 24
   }
 
-  var configuration = Configuration()
+  var configuration = ImagePickerConfiguration()
 
   lazy open var collectionView: UICollectionView = { [unowned self] in
     let collectionView = UICollectionView(frame: CGRect.zero,
@@ -90,7 +90,7 @@ open class ImageGalleryView: UIView {
 
   // MARK: - Initializers
 
-  public init(configuration: Configuration? = nil) {
+  public init(configuration: ImagePickerConfiguration? = nil) {
     if let configuration = configuration {
       self.configuration = configuration
     }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -11,7 +11,7 @@ import Photos
 
 open class ImagePickerController: UIViewController {
 
-  let configuration: Configuration
+  let configuration: ImagePickerConfiguration
 
   struct GestureConstants {
     static let maximumHeight: CGFloat = 200
@@ -91,18 +91,18 @@ open class ImagePickerController: UIViewController {
 
   // MARK: - Initialization
 
-  @objc public required init(configuration: Configuration = Configuration()) {
+  @objc public required init(configuration: ImagePickerConfiguration = ImagePickerConfiguration()) {
     self.configuration = configuration
     super.init(nibName: nil, bundle: nil)
   }
 
   public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-    self.configuration = Configuration()
+    self.configuration = ImagePickerConfiguration()
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }
   
   public required init?(coder aDecoder: NSCoder) {
-    self.configuration = Configuration()
+    self.configuration = ImagePickerConfiguration()
     super.init(coder: aDecoder)
   }
 

--- a/Source/TopView/TopView.swift
+++ b/Source/TopView/TopView.swift
@@ -14,7 +14,7 @@ open class TopView: UIView {
     static let height: CGFloat = 34
   }
 
-  var configuration = Configuration()
+  var configuration = ImagePickerConfiguration()
 
   var currentFlashIndex = 0
   let flashButtonTitles = ["AUTO", "ON", "OFF"]
@@ -50,7 +50,7 @@ open class TopView: UIView {
 
   // MARK: - Initializers
 
-  public init(configuration: Configuration? = nil) {
+  public init(configuration: ImagePickerConfiguration? = nil) {
     if let configuration = configuration {
       self.configuration = configuration
     }


### PR DESCRIPTION
I think any project will have a configuration to its own and usually this class is named Configuration, I faced this problem already, when I try to compile the project, it gets an error "Duplicate interface definition for class 'Configuration' ". but ImagePickerConfiguration is a unique configuration for ImagePicker.

So I forked the project and tried to change the name and it worked! so I think it may help 