### PR TITLE
fix and simplify bundle resource path

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -4,10 +4,7 @@ import Photos
 
 extension Bundle {
     static func myResourceBundle() -> Bundle? {
-        let bundles = Bundle.allBundles
-        let bundlePaths = bundles.compactMap { $0.resourceURL?.appendingPathComponent("ImagePicker", isDirectory: false).appendingPathExtension("bundle") }
-
-        return bundlePaths.compactMap({ Bundle(url: $0) }).first
+        return Bundle(for: ImagePickerController.self)
     }
 }
 


### PR DESCRIPTION
This change simplifies the retrieval of the ImagePicker bundle.
It also fixes a bug on iOS 14, where image resources did not load because the bundle isn't resolved properly.
fixes #479 